### PR TITLE
Warning cleanup and module rename

### DIFF
--- a/doc/Design.org
+++ b/doc/Design.org
@@ -1,0 +1,81 @@
+* Overview
+
+Surveyor is a tool for interactively exploring and visualizing programs and program executions.  It supports a number of program formats including:
+- LLVM
+- JVM
+- Binaries (x86_64, PowerPC, and soon ARM)
+
+Its primary function is to explore the functions in programs in a uniform interactive fashion.  It also supports symbolic execution and can act as a symbolic debugger.  Surveyor separates its core functionality and data model (surveyor-core) from the various GUI frontends.  The intent is that all interesting logic lives in surveyor-core, while the user interfaces implement only display logic.  The interaction model of surveyor is loosely inspired by emacs and gdb.  The currently supported interface is a TUI based on the brick library.  There is a bitrotted QML interface.  A web UI is planned.
+
+This document describes the design and general architecture of Surveyor.
+
+
+* Design
+
+** General Components
+
+There are a number of components that are not specific to Surveyor (but are not yet standalone libraries).  The common functionality is largely focused on an emacs-inspired command system.  Commands are actions triggerable by users and also usable programmatically.
+
+*** Commands
+
+Commands are actions that can be triggered by users or invoked programmatically.  Commands can have arguments.  When invoked by a user, commands can prompt for their arguments or take them from the current contextual environment.  It is desired that as much functionality as possible should be exposed as commands.  Commands are strongly typed, in that their number and types of arguments are part of their specifications.  The type-level embedding ensures that commands can only be invoked on well-typed argument lists.
+
+*** Minibuffer
+
+The minibuffer in the TUI is the interface by which users can invoke commands and be prompted for arguments.  It supports completion and a mechanism for prompting for and typechecking arguments.
+
+*** Keymaps
+
+Keymaps map keybindings to commands.  They can vary by context and have an overlay-like behavior, much like emacs keymaps.
+
+*** Asynchronous Computation
+
+Surveyor performs all of its expensive computations in worker threads asynchronously and reports results via message queues to the main thread in order to avoid blocking the UI.  This is difficult in Haskell, as it is easy to accidentally construct a thunk in a worker thread and pass it back to the UI unevaluated.  Surveyor works hard to prevent this.  Some of the relevant modules include:
+- Control.NF (enforced normal form evaluation)
+- Control.Once (ensure that structures aren't traversed multiple times during normal form evaluation)
+
+These efforts are often hindered by a lack of ~NFData~ instances for many types.  We mostly just ignore those cases and hope for the best.  One day adding the missing instances will be systematically tackled based on profiling.
+
+** Surveyor Services
+
+The intended design of surveyor is that all interesting logic should live in surveyor-core.  It exposes a single module to clients: Surveyor.Core.
+
+*** Context
+
+Surveyor(-core) maintains a notion of the current context within an interactive session.  It is essentially a stack of basic blocks that records the history of a user's navigation.  This allows for easy back/forward navigation, which is implemented as maintaining a pointer into the stack.
+
+The context stack provides a way for commands that need a function, block, or instruction as an argument to get one: by inspecting the current context and choosing the active item of the correct type.
+
+*** Uniform IR Visualization
+
+Surveyor provides a uniform view (in terms of functions, blocks, and instructions) for a number of different intermediate representations.  This includes the raw format of an input program (e.g., LLVM IR, JVM bytecode, or machine code), as well as derived IRs (macaw IR as a product of machine code discovery and crucible IR, which is the input to symbolic execution).
+
+*** Symbolic Execution
+
+Surveyor supports managing multiple concurrent symbolic execution tasks.  The current interface is that the function in the current context can be symbolically executed with fully symbolic inputs.  This needs to be augmented to allow for memory states to be specified (currently, only formal input parameters are accounted for).
+
+Symbolic execution is provided by the Crucible library, which is both an intermediate representation for imperative programs and a symbolic execution engine.
+
+* Coding Standards
+
+There are no hard rules, but general principles to strive for include:
+
+- Prefer qualified imports
+
+  The goal is to make it obvious what modules names come from at a glance.  Explicit imports are fine for short import lists.  Additionally, there could be some good arguments for exceptions for some modules in Base.
+
+- Try to avoid re-exports
+
+  Re-exports tend to make it difficult to find the original definition of a type or function.  Reasonable exceptions include types that need to be split into separate modules to break import cycles.
+
+- Prefer newtypes to type aliases
+
+  Type aliases do not provide any abstraction and often require the reader to understand the definition of the alias in order to effectively work with them.
+
+- Wrap monad transformer stacks in newtypes
+
+  It helps maintain abstraction boundaries and avoids updating call sites if the definition of the stack needs to change.  Deriving the ~Monad*~ classes from mtl (where sensible) additionally helps with compatibility.
+
+- Optimize code for reading rather than writing
+
+  Clarity is more helpful than brevity, especially when code will have a long life.

--- a/surveyor-brick/surveyor-brick.cabal
+++ b/surveyor-brick/surveyor-brick.cabal
@@ -51,7 +51,7 @@ library
                        generic-lens >= 0.5.1.0 && < 1.3,
                        parameterized-utils >= 1 && < 3,
                        text-zipper,
-                       megaparsec >= 7 && < 8,
+                       megaparsec >= 7 && < 9,
                        IntervalMap >= 0.6 && < 0.7,
                        regex-tdfa >= 1 && < 2,
                        brick >= 0.47 && < 1,

--- a/surveyor-core/src/Surveyor/Core.hs
+++ b/surveyor-core/src/Surveyor/Core.hs
@@ -150,8 +150,6 @@ module Surveyor.Core (
   K.modeKeybindings,
   K.lookupKeyCommand,
   -- * Logging
-  logMessage,
-  logDiagnostic,
   CE.LogLevel(..),
   -- * Defaults
   defaultKeymap
@@ -168,7 +166,7 @@ import qualified Surveyor.Core.Chan as CS
 import qualified Surveyor.Core.Command as CC
 import           Surveyor.Core.Commands
 import qualified Surveyor.Core.Context as CCX
-import qualified Surveyor.Core.Context.SymbolicExecution as SymEx
+import qualified Surveyor.Core.SymbolicExecution as SymEx
 import qualified Surveyor.Core.EchoArea as EA
 import qualified Surveyor.Core.Events as CE
 import qualified Surveyor.Core.IRRepr as IR

--- a/surveyor-core/src/Surveyor/Core/Architecture/Class.hs
+++ b/surveyor-core/src/Surveyor/Core/Architecture/Class.hs
@@ -36,6 +36,7 @@ import           GHC.Generics ( Generic )
 import           Control.DeepSeq ( NFData, rnf, deepseq )
 import qualified Control.Once as O
 import qualified Data.ByteString as BS
+import           Data.Kind ( Type )
 import qualified Data.Map as M
 import           Data.Maybe ( isJust )
 import           Data.Parameterized.Classes ( testEquality )
@@ -95,11 +96,11 @@ type ArchConstraints arch s = (Eq (Address arch s),
 --
 -- This is a standalone type family because it needs access to a parameter (sym)
 -- that isn't a class method.
-type family CruciblePersonality arch sym :: *
+type family CruciblePersonality arch sym :: Type
 
-class (IR arch s, CCE.IsSyntaxExtension (CrucibleExt arch)) => Architecture (arch :: *) (s :: *) where
-  data ArchResult arch s :: *
-  type CrucibleExt arch :: *
+class (IR arch s, CCE.IsSyntaxExtension (CrucibleExt arch)) => Architecture (arch :: Type) (s :: Type) where
+  data ArchResult arch s :: Type
+  type CrucibleExt arch :: Type
 
   -- | Extract the nonce for the analysis result
   archNonce :: AnalysisResult arch s -> NG.Nonce s arch
@@ -158,11 +159,11 @@ data BlockMapping arch ir s =
 -- is weaker than 'Architecture', as we can't implement 'Architecture' for some
 -- of our IRs (like macaw and crucible).  The split lets us render those
 -- architectures without requiring partial instances of 'Architecture'
-class (ArchConstraints arch s) => IR (arch :: *) (s :: *) where
-  data Instruction arch s :: *
-  data Operand arch s :: *
-  data Opcode arch s :: *
-  data Address arch s :: *
+class (ArchConstraints arch s) => IR (arch :: Type) (s :: Type) where
+  data Instruction arch s :: Type
+  data Operand arch s :: Type
+  data Opcode arch s :: Type
+  data Address arch s :: Type
   opcode :: Instruction arch s -> Opcode arch s
   operands :: Instruction arch s -> OL.OperandList (Operand arch s)
   boundValue :: Instruction arch s -> Maybe (Operand arch s)

--- a/surveyor-core/src/Surveyor/Core/Architecture/JVM.hs
+++ b/surveyor-core/src/Surveyor/Core/Architecture/JVM.hs
@@ -22,7 +22,7 @@ import qualified Control.Once as O
 import qualified Data.Foldable as F
 import           Data.Int ( Int16, Int32 )
 import qualified Data.Map.Strict as M
-import           Data.Maybe ( fromMaybe, isJust )
+import           Data.Maybe ( fromMaybe )
 import           Data.Parameterized.Classes
 import qualified Data.Parameterized.Nonce as NG
 import qualified Data.Text as T

--- a/surveyor-core/src/Surveyor/Core/Architecture/LLVM.hs
+++ b/surveyor-core/src/Surveyor/Core/Architecture/LLVM.hs
@@ -23,7 +23,7 @@ import qualified Control.Once as O
 import qualified Data.Foldable as F
 import qualified Data.IORef as IOR
 import qualified Data.Map.Strict as M
-import           Data.Maybe ( catMaybes, isJust, fromMaybe, mapMaybe )
+import           Data.Maybe ( catMaybes, fromMaybe, mapMaybe )
 import           Data.Parameterized.Classes
 import qualified Data.Parameterized.Context as Ctx
 import qualified Data.Parameterized.Nonce as NG

--- a/surveyor-core/src/Surveyor/Core/Architecture/MC.hs
+++ b/surveyor-core/src/Surveyor/Core/Architecture/MC.hs
@@ -27,7 +27,6 @@ import qualified Data.Foldable as F
 import qualified Data.Functor.Const as C
 import           Data.Int ( Int16, Int64 )
 import qualified Data.Map as M
-import           Data.Monoid ( (<>) )
 import           Data.Parameterized.Classes ( ShowF(showF) )
 import qualified Data.Parameterized.TraversableFC as FC
 import qualified Data.Parameterized.Map as MapF

--- a/surveyor-core/src/Surveyor/Core/Architecture/Macaw.hs
+++ b/surveyor-core/src/Surveyor/Core/Architecture/Macaw.hs
@@ -21,10 +21,11 @@ module Surveyor.Core.Architecture.Macaw (
   ) where
 
 import           Control.DeepSeq ( NFData(rnf), deepseq )
-import           Control.Lens ( (^.) )
 import qualified Control.Exception as X
+import           Control.Lens ( (^.) )
 import qualified Data.Foldable as F
 import qualified Data.IORef as IOR
+import           Data.Kind ( Type )
 import qualified Data.Macaw.CFG as MC
 import qualified Data.Macaw.Discovery.State as MC
 import qualified Data.Macaw.Types as MT
@@ -40,8 +41,8 @@ import qualified Data.Set as S
 import qualified Data.Text as T
 import qualified Data.Vector as V
 import           Data.Word ( Word64 )
-import qualified Fmt as Fmt
 import           Fmt ( (||+), (+|), (|+) )
+import qualified Fmt as Fmt
 import qualified Renovate as R
 import qualified Text.PrettyPrint.ANSI.Leijen as PP
 import           Text.Printf ( printf )
@@ -149,7 +150,7 @@ toMacawBlock nonceGen dfi fh (baddr, b) = do
                 return ((InstructionNumber insnIdx, MacawStmt s mbv ops) : rest)
 
 data NonceCache ids s where
-  NonceCache :: forall (oldNonce :: MT.Type -> *) (newNonce :: MT.Type -> *) ids s
+  NonceCache :: forall (oldNonce :: MT.Type -> Type) (newNonce :: MT.Type -> Type) ids s
               . ( oldNonce ~ PN.Nonce ids
                 , newNonce ~ PN.Nonce s
                 )

--- a/surveyor-core/src/Surveyor/Core/Commands.hs
+++ b/surveyor-core/src/Surveyor/Core/Commands.hs
@@ -44,7 +44,7 @@ import qualified Surveyor.Core.Arguments as AR
 import qualified Surveyor.Core.Chan as C
 import qualified Surveyor.Core.Command as C
 import qualified Surveyor.Core.Context as CCX
-import qualified Surveyor.Core.Context.SymbolicExecution as SymEx
+import qualified Surveyor.Core.SymbolicExecution as SymEx
 import           Surveyor.Core.Events ( Events(..) )
 import qualified Surveyor.Core.State as CS
 

--- a/surveyor-core/src/Surveyor/Core/Context.hs
+++ b/surveyor-core/src/Surveyor/Core/Context.hs
@@ -63,7 +63,7 @@ import qualified Data.Vector as V
 import qualified Surveyor.Core.Architecture as CA
 import qualified Surveyor.Core.IRRepr as IR
 import qualified Surveyor.Core.TranslationCache as TC
-import qualified Surveyor.Core.Context.SymbolicExecution as SE
+import qualified Surveyor.Core.SymbolicExecution as SE
 import qualified Surveyor.Core.OperandList as OL
 
 -- | A context focused (at some point) by the user, and used to inform drawing

--- a/surveyor-core/src/Surveyor/Core/Events.hs
+++ b/surveyor-core/src/Surveyor/Core/Events.hs
@@ -18,9 +18,9 @@ import qualified Renovate as R
 
 import qualified Surveyor.Core.Architecture as A
 import qualified Surveyor.Core.Command as C
-import qualified Surveyor.Core.Context.SymbolicExecution.Config as SE
-import qualified Surveyor.Core.Context.SymbolicExecution.Session as CSS
-import qualified Surveyor.Core.Context.SymbolicExecution.State as SES
+import qualified Surveyor.Core.SymbolicExecution.Config as SE
+import qualified Surveyor.Core.SymbolicExecution.Session as CSS
+import qualified Surveyor.Core.SymbolicExecution.State as SES
 import qualified Surveyor.Core.IRRepr as IR
 
 data LogLevel = LogDebug

--- a/surveyor-core/src/Surveyor/Core/Mode.hs
+++ b/surveyor-core/src/Surveyor/Core/Mode.hs
@@ -14,13 +14,14 @@ module Surveyor.Core.Mode (
   prettyMode
   ) where
 
+import           Data.Kind ( Type )
 import           Data.Maybe ( isJust )
-import           Data.Parameterized.Classes
+import qualified Data.Parameterized.Classes as PC
 import qualified Data.Parameterized.Nonce as PN
 import qualified Data.Parameterized.TH.GADT as PT
 import qualified Data.Text as T
-import qualified Fmt as Fmt
 import           Fmt ( (+|), (||+) )
+import qualified Fmt as Fmt
 
 import           Surveyor.Core.IRRepr ( IRRepr )
 
@@ -42,9 +43,9 @@ data UIMode s k where
   -- sBlockList in the State)
   BlockSelector :: UIMode s NormalK
   -- | View a block
-  BlockViewer :: PN.Nonce s (arch :: *) -> IRRepr arch ir -> UIMode s NormalK
+  BlockViewer :: PN.Nonce s (arch :: Type) -> IRRepr arch ir -> UIMode s NormalK
   -- | View a function
-  FunctionViewer :: PN.Nonce s (arch :: *) -> IRRepr arch ir -> UIMode s NormalK
+  FunctionViewer :: PN.Nonce s (arch :: Type) -> IRRepr arch ir -> UIMode s NormalK
   -- | View the semantics for an individual selected base IR instruction
   SemanticsViewer :: UIMode s NormalK
   -- | A UI for setting up the basic configuration of the symbolic execution
@@ -73,25 +74,25 @@ data SomeUIMode s where
 
 $(return [])
 
-instance TestEquality (UIMode s) where
+instance PC.TestEquality (UIMode s) where
   testEquality = $(PT.structuralTypeEquality [t| UIMode |]
-                   [ (PT.TypeApp (PT.TypeApp (PT.ConType [t|PN.Nonce |]) PT.AnyType) PT.AnyType, [|testEquality|])
-                   , (PT.TypeApp (PT.TypeApp (PT.ConType [t| UIMode |]) PT.AnyType) PT.AnyType, [|testEquality|])
-                   , (PT.TypeApp (PT.TypeApp (PT.ConType [t| IRRepr |]) PT.AnyType) PT.AnyType, [|testEquality|])
+                   [ (PT.TypeApp (PT.TypeApp (PT.ConType [t|PN.Nonce |]) PT.AnyType) PT.AnyType, [|PC.testEquality|])
+                   , (PT.TypeApp (PT.TypeApp (PT.ConType [t| UIMode |]) PT.AnyType) PT.AnyType, [|PC.testEquality|])
+                   , (PT.TypeApp (PT.TypeApp (PT.ConType [t| IRRepr |]) PT.AnyType) PT.AnyType, [|PC.testEquality|])
                    ])
 
-instance OrdF (UIMode s) where
+instance PC.OrdF (UIMode s) where
   compareF = $(PT.structuralTypeOrd [t| UIMode |]
-                   [ (PT.TypeApp (PT.TypeApp (PT.ConType [t|PN.Nonce |]) PT.AnyType) PT.AnyType, [|compareF|])
-                   , (PT.TypeApp (PT.TypeApp (PT.ConType [t| UIMode |]) PT.AnyType) PT.AnyType, [|compareF|])
-                   , (PT.TypeApp (PT.TypeApp (PT.ConType [t| IRRepr |]) PT.AnyType) PT.AnyType, [|compareF|])
+                   [ (PT.TypeApp (PT.TypeApp (PT.ConType [t|PN.Nonce |]) PT.AnyType) PT.AnyType, [|PC.compareF|])
+                   , (PT.TypeApp (PT.TypeApp (PT.ConType [t| UIMode |]) PT.AnyType) PT.AnyType, [|PC.compareF|])
+                   , (PT.TypeApp (PT.TypeApp (PT.ConType [t| IRRepr |]) PT.AnyType) PT.AnyType, [|PC.compareF|])
                    ])
 
 deriving instance Eq (SomeUIMode s)
 deriving instance Ord (SomeUIMode s)
 
 instance Eq (UIMode s k) where
-  u1 == u2 = isJust (testEquality u1 u2)
+  u1 == u2 = isJust (PC.testEquality u1 u2)
 
 instance Ord (UIMode s k) where
-  compare u1 u2 = toOrdering (compareF u1 u2)
+  compare u1 u2 = PC.toOrdering (PC.compareF u1 u2)

--- a/surveyor-core/src/Surveyor/Core/State.hs
+++ b/surveyor-core/src/Surveyor/Core/State.hs
@@ -46,7 +46,7 @@ import qualified Surveyor.Core.Architecture as A
 import qualified Surveyor.Core.Arguments as AR
 import qualified Surveyor.Core.Chan as C
 import qualified Surveyor.Core.Context as CC
-import qualified Surveyor.Core.Context.SymbolicExecution as SE
+import qualified Surveyor.Core.SymbolicExecution as SE
 import qualified Surveyor.Core.EchoArea as EA
 import           Surveyor.Core.Events ( Events(LogDiagnostic), LogLevel )
 import           Surveyor.Core.Keymap ( Keymap )

--- a/surveyor-core/src/Surveyor/Core/SymbolicExecution.hs
+++ b/surveyor-core/src/Surveyor/Core/SymbolicExecution.hs
@@ -12,7 +12,7 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
-module Surveyor.Core.Context.SymbolicExecution (
+module Surveyor.Core.SymbolicExecution (
   -- * Configuration
   SymbolicExecutionConfig,
   SomeFloatModeRepr(..),
@@ -88,8 +88,8 @@ import qualified Surveyor.Core.Architecture as CA
 import qualified Surveyor.Core.Chan as SCC
 import qualified Surveyor.Core.Events as SCE
 
-import           Surveyor.Core.Context.SymbolicExecution.Config
-import           Surveyor.Core.Context.SymbolicExecution.State
+import           Surveyor.Core.SymbolicExecution.Config
+import           Surveyor.Core.SymbolicExecution.State
 
 -- Setup of the symbolic execution engine (parameters and globals)
 

--- a/surveyor-core/src/Surveyor/Core/SymbolicExecution/Config.hs
+++ b/surveyor-core/src/Surveyor/Core/SymbolicExecution/Config.hs
@@ -8,7 +8,7 @@
 -- | Configuration for the symbolic execution engine
 --
 -- This is a separate module to break an import cycle with the Events module.
-module Surveyor.Core.Context.SymbolicExecution.Config (
+module Surveyor.Core.SymbolicExecution.Config (
   -- * Session Identifiers
   SessionID,
   newSessionID,
@@ -34,7 +34,7 @@ import qualified Data.Text as T
 import qualified What4.Expr.Builder as WEB
 import qualified What4.InterpretedFloatingPoint as WIF
 
-import           Surveyor.Core.Context.SymbolicExecution.Session ( SessionID, newSessionID )
+import           Surveyor.Core.SymbolicExecution.Session ( SessionID, newSessionID )
 
 data Solver = CVC4 | Yices | Z3
   deriving (Eq, Ord, Show)

--- a/surveyor-core/src/Surveyor/Core/SymbolicExecution/Session.hs
+++ b/surveyor-core/src/Surveyor/Core/SymbolicExecution/Session.hs
@@ -1,5 +1,5 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
-module Surveyor.Core.Context.SymbolicExecution.Session (
+module Surveyor.Core.SymbolicExecution.Session (
   SessionID,
   newSessionID
   ) where

--- a/surveyor-core/src/Surveyor/Core/SymbolicExecution/State.hs
+++ b/surveyor-core/src/Surveyor/Core/SymbolicExecution/State.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE RankNTypes #-}
-module Surveyor.Core.Context.SymbolicExecution.State (
+module Surveyor.Core.SymbolicExecution.State (
   SymbolicState(..)
   ) where
 
@@ -13,7 +13,7 @@ import qualified What4.Expr.Builder as WEB
 import qualified What4.Protocol.Online as WPO
 
 import qualified Surveyor.Core.Architecture as CA
-import           Surveyor.Core.Context.SymbolicExecution.Config
+import           Surveyor.Core.SymbolicExecution.Config
 
 data SymbolicState arch s solver fm init reg =
   SymbolicState { symbolicConfig :: SymbolicExecutionConfig s

--- a/surveyor-core/surveyor-core.cabal
+++ b/surveyor-core/surveyor-core.cabal
@@ -5,7 +5,7 @@ description:         This includes core functionality reused among several UIs
 license:             BSD3
 license-file:        LICENSE
 author:              Tristan Ravitch
-maintainer:          tristan@nochair.net
+maintainer:          tristan@galois.com
 -- copyright:           
 category:            Reverse-Engineering
 build-type:          Simple
@@ -67,7 +67,7 @@ library
                        generic-lens >= 0.5.1.0 && < 1.3,
                        parameterized-utils >= 1 && < 3,
                        text-zipper,
-                       megaparsec >= 7 && < 8,
+                       megaparsec >= 7 && < 9,
                        IntervalMap >= 0.6 && < 0.7,
                        regex-tdfa >= 1 && < 2,
                        vty,

--- a/surveyor-core/surveyor-core.cabal
+++ b/surveyor-core/surveyor-core.cabal
@@ -31,10 +31,10 @@ library
                        Surveyor.Core.Command
                        Surveyor.Core.Commands
                        Surveyor.Core.Context
-                       Surveyor.Core.Context.SymbolicExecution
-                       Surveyor.Core.Context.SymbolicExecution.Config
-                       Surveyor.Core.Context.SymbolicExecution.Session
-                       Surveyor.Core.Context.SymbolicExecution.State
+                       Surveyor.Core.SymbolicExecution
+                       Surveyor.Core.SymbolicExecution.Config
+                       Surveyor.Core.SymbolicExecution.Session
+                       Surveyor.Core.SymbolicExecution.State
                        Surveyor.Core.EchoArea
                        Surveyor.Core.Events
                        Surveyor.Core.IRRepr


### PR DESCRIPTION
The symbolic execution code doesn't really belong under context; it is its own
top-level feature