### PR TITLE
Use lumberjack as the logging core

### DIFF
--- a/surveyor-brick/src/Surveyor/Brick.hs
+++ b/surveyor-brick/src/Surveyor/Brick.hs
@@ -249,7 +249,9 @@ emptyState mfp mloader ng customEventChan = do
   return C.S { C.sInputFile = mfp
              , C.sLoader = mloader
              , C.sLogStore = mempty
-             , C.sLogAction = C.logToState customEventChan
+             , C.sLogActions = C.LoggingActions { C.sStateLogger = C.logToState customEventChan
+                                                , C.sFileLogger = Nothing
+                                                }
              , C.sDiagnosticLevel = C.Debug
              , C.sEchoArea = C.echoArea 10 (resetEchoArea customEventChan)
              , C.sUIMode = C.SomeUIMode C.Diags

--- a/surveyor-brick/src/Surveyor/Brick.hs
+++ b/surveyor-brick/src/Surveyor/Brick.hs
@@ -8,9 +8,9 @@
 module Surveyor.Brick ( surveyor ) where
 
 import qualified Brick as B
-import qualified Brick.Markup as B
-import           Brick.Markup ( (@?) )
 import qualified Brick.BChan as B
+import           Brick.Markup ( (@?) )
+import qualified Brick.Markup as B
 import qualified Brick.Widgets.Border as B
 import qualified Brick.Widgets.List as B
 import           Control.Lens ( (^.) )
@@ -18,11 +18,13 @@ import qualified Data.Foldable as F
 import           Data.Maybe ( fromMaybe, mapMaybe )
 import           Data.Parameterized.Classes
 import qualified Data.Parameterized.Nonce as PN
-import qualified Data.Sequence as Seq
 import qualified Data.Text as T
 import qualified Data.Text.Prettyprint.Doc as PP
+import qualified Data.Text.Prettyprint.Doc.Render.Text as PPT
 import qualified Data.Traversable as T
 import           Data.Void ( Void )
+import           Fmt ( (+|), (||+) )
+import qualified Fmt as Fmt
 import qualified Graphics.Vty as V
 
 import qualified Surveyor.Core as C
@@ -48,22 +50,46 @@ drawSummaryTableEntry :: Int -> (T.Text, T.Text) -> B.Widget Names
 drawSummaryTableEntry keyColWidth (key, val) =
   B.padRight (B.Pad (keyColWidth - T.length key)) (B.txt key) B.<+> B.txt val
 
-drawDiagnostics :: Seq.Seq (Maybe C.LogLevel, T.Text) -> B.Widget Names
+drawDiagnostics :: C.LogStore -> B.Widget Names
 drawDiagnostics diags = B.viewport DiagnosticView B.Vertical body
   where
-    body = B.vBox [ B.markup (renderLogLevel logLevel) B.<+> B.txtWrap t
-                  | (logLevel, t) <- F.toList diags
+    -- FIXME: Make the history length configurable
+    --
+    -- We do want to limit what we render, though, because pointlessly rendering
+    -- a huge history really slows down brick
+    body = B.vBox [ renderMessage msg
+                    -- B.markup (renderSeverity logLevel) B.<+> B.txtWrap t
+                  | msg <- F.toList (C.takeLogs 100 diags)
                   ]
-    renderLogLevel mll =
-      case mll of
-        Nothing -> ""
-        Just ll ->
-          case ll of
-            C.LogDebug -> "DEBUG" @? "log-debug" <> ":"
-            C.LogInfo -> "INFO" @? "log-info" <> ":"
-            C.LogWarning -> "WARN" @? "log-warning" <> ":"
-            C.LogError -> "ERROR" @? "log-error" <> ":"
-            C.LogFatal -> "FATAL" @? "log-fatal" <> ":"
+    renderMessage msg =
+      let tm = renderTime (C.logTime msg)
+          sev = renderSeverity (C.logLevel (C.logMsg msg))
+          comp = renderComponent (C.logSource (C.logMsg msg))
+      in case C.logText (C.logMsg msg) of
+        [] -> B.markup tm B.<+> B.markup sev B.<+> B.markup comp
+        [txt] -> B.markup tm B.<+> B.markup sev B.<+> B.markup comp B.<+> B.txtWrap txt
+        txts -> B.vBox ( B.markup tm B.<+> B.markup sev B.<+> B.markup comp
+                       : map B.txtWrap txts
+                       )
+    renderComponent comp =
+      case comp of
+        C.Unspecified -> ""
+        C.Loader -> "Loader" @? "log-component"
+        C.EventHandler nm -> Fmt.fmt ("Event[" +| nm ||+ "]") @? "log-component"
+        C.CommandCallback nm -> Fmt.fmt ("Command[" +| nm ||+ "]") @? "log-component"
+        C.EchoAreaUpdate -> ""
+
+    renderTime tm = PPT.renderStrict (PP.layoutCompact (PP.pretty tm)) @? "log-time"
+
+    renderSeverity sev =
+      case sev of
+        C.Debug -> "DEBUG" @? "log-debug" <> ":"
+        C.Info -> "INFO" @? "log-info" <> ":"
+        C.Warn -> "WARN" @? "log-warning" <> ":"
+        C.Error -> "ERROR" @? "log-error" <> ":"
+        -- Requested messages were explicitly initiated from a user action and
+        -- shouldn't have a visible tag (and are always displayed)
+        C.Requested -> ""
 
 -- | Draw a status bar based on the current state
 --
@@ -144,7 +170,7 @@ drawUIMode :: (C.Architecture arch s)
            -> [B.Widget Names]
 drawUIMode binFileName archState s uim =
   case uim of
-    C.Diags -> drawAppShell s (drawDiagnostics (C.sDiagnosticLog s))
+    C.Diags -> drawAppShell s (drawDiagnostics (C.sLogStore s))
     C.Summary -> drawAppShell s (drawSummary binFileName binfo)
     C.FunctionSelector -> drawAppShell s (FS.renderFunctionSelector (archState ^. BH.functionSelectorG))
     C.BlockSelector -> drawAppShell s (BS.renderBlockSelector (archState ^. BH.blockSelectorG))
@@ -222,8 +248,9 @@ emptyState mfp mloader ng customEventChan = do
   let uiExt = BH.mkExtension (C.writeChan customEventChan) n0 addrParser "M-x"
   return C.S { C.sInputFile = mfp
              , C.sLoader = mloader
-             , C.sDiagnosticLog = Seq.empty
-             , C.sDiagnosticLevel = C.LogDebug
+             , C.sLogStore = mempty
+             , C.sLogAction = C.logToState customEventChan
+             , C.sDiagnosticLevel = C.Debug
              , C.sEchoArea = C.echoArea 10 (resetEchoArea customEventChan)
              , C.sUIMode = C.SomeUIMode C.Diags
              , C.sAppState = maybe C.AwaitingFile (const C.Loading) mfp

--- a/surveyor-brick/src/Surveyor/Brick/Command.hs
+++ b/surveyor-brick/src/Surveyor/Brick/Command.hs
@@ -44,9 +44,13 @@ showMacawBlockC =
   where
     doc = "Show the macaw IR of the currently-selected block"
     callback :: Callback s st '[]
-    callback = \eventChan (C.getNonce -> C.SomeNonce archNonce) PL.Nil ->do
-      C.writeChan eventChan (C.LogDiagnostic (Just C.LogDebug) "Showing macaw IR")
-      C.writeChan eventChan (C.ViewBlock archNonce C.MacawRepr)
+    callback = \eventChan sst@(C.SomeState st) PL.Nil -> do
+      case C.getNonce sst of
+        C.SomeNonce archNonce -> do
+          C.logMessage st (C.msgWith { C.logText = ["Showing Macaw IR"]
+                                     , C.logLevel = C.Debug
+                                     })
+          C.writeChan eventChan (C.ViewBlock archNonce C.MacawRepr)
 
 
 showCrucibleBlockC :: forall s st e u . (C.HasNonce st, st ~ C.S e u) => Command s st '[]
@@ -55,9 +59,13 @@ showCrucibleBlockC =
   where
     doc = "Show the crucible IR of the currently-selected block"
     callback :: Callback s st '[]
-    callback = \eventChan (C.getNonce -> C.SomeNonce archNonce) PL.Nil -> do
-      C.writeChan eventChan (C.LogDiagnostic (Just C.LogDebug) "Showing crucible IR")
-      C.writeChan eventChan (C.ViewBlock archNonce C.CrucibleRepr)
+    callback = \eventChan sst@(C.SomeState st) PL.Nil -> do
+      case C.getNonce sst of
+        C.SomeNonce archNonce -> do
+          C.logMessage st (C.msgWith { C.logText = ["Showing Crucible IR"]
+                                     , C.logLevel = C.Debug
+                                     })
+          C.writeChan eventChan (C.ViewBlock archNonce C.CrucibleRepr)
 
 showBaseBlockC :: forall s st . (C.HasNonce st) => Command s st '[]
 showBaseBlockC =

--- a/surveyor-brick/src/Surveyor/Brick/Handlers.hs
+++ b/surveyor-brick/src/Surveyor/Brick/Handlers.hs
@@ -465,6 +465,10 @@ handleCustomEvent s0 evt =
         Nothing -> return ()
         Just (task, _) -> liftIO $ A.cancel task
       let s1 = s0 & C.lLogActions . C.lFileLogger .~ Just (newTask, newAction)
+      liftIO $ C.logMessage s1 (C.msgWith { C.logLevel = C.Info
+                                          , C.logText = ["Logging to file " <> T.pack logFile]
+                                          , C.logSource = C.EventHandler "SetLogFile"
+                                          })
       B.continue $! C.State s1
 
     C.DisableFileLogging -> do
@@ -563,7 +567,7 @@ stateFromAnalysisResult s0 ares newDiags state uiMode = do
   return C.S { C.sLogStore = nextLogStore
              , C.sDiagnosticLevel = C.sDiagnosticLevel s0
              , C.sLogActions = C.LoggingActions { C.sStateLogger = C.logToState (C.sEventChannel s0)
-                                                , C.sFileLogger = Nothing
+                                                , C.sFileLogger = C.sFileLogger (C.sLogActions s0)
                                                 }
              , C.sUIMode = uiMode
              , C.sAppState = state

--- a/surveyor-brick/src/Surveyor/Brick/Handlers.hs
+++ b/surveyor-brick/src/Surveyor/Brick/Handlers.hs
@@ -31,8 +31,8 @@ import           GHC.Generics ( Generic )
 
 import qualified Brick as B
 import qualified Control.Concurrent.Async as A
-import qualified Control.Lens as L
 import           Control.Lens ( (&), (^.), (.~), (%~), (^?), _Just )
+import qualified Control.Lens as L
 import           Control.Monad.IO.Class ( liftIO )
 import qualified Control.NF as NF
 import qualified Data.Foldable as F
@@ -48,8 +48,8 @@ import qualified Data.Sequence as Seq
 import qualified Data.Text as T
 import qualified Data.Text.Prettyprint.Doc as PP
 import qualified Data.Vector as V
-import qualified Fmt as Fmt
 import           Fmt ( (+|), (|+), (||+) )
+import qualified Fmt as Fmt
 import qualified Graphics.Vty as V
 import           Text.Printf ( printf )
 
@@ -151,20 +151,29 @@ handleCustomEvent s0 evt =
       s1 <- liftIO $ stateFromAnalysisResult s0 bar Seq.empty C.Loading (C.sUIMode s0)
       B.continue (C.State s1)
     C.AnalysisFailure exn -> do
-      liftIO (C.sEmitEvent s0 (C.LogDiagnostic (Just C.LogError) (Fmt.fmt ("Analysis failure: " +| exn ||+ ""))))
+      liftIO $ C.logMessage s0 (C.msgWith { C.logLevel = C.Error
+                                          , C.logSource = C.EventHandler "Analysis Failure"
+                                          , C.logText = [Fmt.fmt ("Analysis failure: " +| exn ||+ "")]
+                                          })
       B.continue $! C.State s0
     C.ErrorLoadingELFHeader off msg -> do
-      let t = T.pack (printf "ELF Loading error at offset 0x%x: %s" off msg)
-      let s1 = s0 & C.lDiagnosticLog %~ (Seq.|> (Just C.LogError, t))
-      B.continue $! C.State s1
+      liftIO $ C.logMessage s0 (C.msgWith { C.logLevel = C.Error
+                                          , C.logSource = C.EventHandler "ELF Loader"
+                                          , C.logText = [T.pack (printf "ELF Loading error at offset 0x%x: %s" off msg)]
+                                          })
+      B.continue $! C.State s0
     C.ErrorLoadingELF errs -> do
-      let newDiags = map (\d -> (Just C.LogError, Fmt.fmt ("ELF Loading error: " +| d ||+ ""))) errs
-      let s1 = s0 & C.lDiagnosticLog %~ (<> Seq.fromList newDiags)
-      B.continue $! C.State s1
+      liftIO $ C.logMessage s0 (C.msgWith { C.logLevel = C.Error
+                                          , C.logSource = C.EventHandler "ELF Loader"
+                                          , C.logText = map (\d -> Fmt.fmt ("ELF Loading error: " +| d ||+ "")) errs
+                                          })
+      B.continue $! C.State s0
     C.ErrorLoadingLLVM s -> do
-      let t = Fmt.fmt ("Error loading LLVM bitcode: " +| s |+ "")
-      let s1 = s0 & C.lDiagnosticLog %~ (Seq.|> (Just C.LogError, t))
-      B.continue $! C.State s1
+      liftIO $ C.logMessage s0 (C.msgWith { C.logLevel = C.Error
+                                          , C.logSource = C.EventHandler "LLVM Loader"
+                                          , C.logText = [Fmt.fmt ("Error loading LLVM bitcode: " +| s |+ "")]
+                                          })
+      B.continue $! C.State s0
     C.LoadFile filename -> do
       liftIO (F.traverse_ C.cancelLoader (C.sLoader s0))
       loader <- liftIO $ C.asynchronouslyLoad (C.sNonceGenerator s0) (C.sEventChannel s0) filename
@@ -194,9 +203,13 @@ handleCustomEvent s0 evt =
     C.DescribeCommand (C.SomeCommand cmd) -> do
       let msg = T.pack (printf "%s: %s" (C.cmdName cmd) (C.cmdDocstring cmd))
       liftIO (C.sEmitEvent s0 (C.EchoText msg))
-      let s1 = s0 & C.lDiagnosticLog %~ (Seq.|> (Nothing, msg))
-      B.continue $! C.State s1
+      B.continue $! C.State s0
     C.EchoText txt -> do
+      -- All echo area text is mirrored into the log
+      liftIO $ C.logMessage s0 (C.msgWith { C.logLevel = C.Requested
+                                          , C.logSource = C.EchoAreaUpdate
+                                          , C.logText = [txt]
+                                          })
       ea' <- liftIO (C.setEchoAreaText (C.sEchoArea s0) txt)
       B.continue $! C.State (s0 & C.lEchoArea .~ ea')
     C.ResetEchoArea -> B.continue $! C.State (s0 & C.lEchoArea %~ C.resetEchoArea)
@@ -265,7 +278,10 @@ handleCustomEvent s0 evt =
           -- Set the current view to the block viewer (of the appropriate IR)
           --
           -- Note that this doesn't manipulate the context at all
-          liftIO (C.sEmitEvent s0 (C.LogDiagnostic (Just C.LogDebug) (Fmt.fmt ("Viewing a block for repr " +| rep ||+ ""))))
+          liftIO $ C.logMessage s0 (C.msgWith { C.logLevel = C.Debug
+                                              , C.logSource = C.EventHandler "ViewBlock"
+                                              , C.logText = [Fmt.fmt ("Viewing a block for repr " +| rep ||+ "")]
+                                              })
           let s1 = s0 & C.lUIMode .~ C.SomeUIMode (C.BlockViewer archNonce rep)
           B.continue $! C.State s1
       | otherwise -> B.continue (C.State s0)
@@ -340,7 +356,10 @@ handleCustomEvent s0 evt =
       | Just archState <- s0 ^. C.lArchState
       , ares <- archState ^. C.lAnalysisResult
       , Just Refl <- testEquality (s0 ^. C.lNonce) archNonce -> do
-          liftIO (C.sEmitEvent s0 (C.LogDiagnostic (Just C.LogDebug) (Fmt.fmt ("Finding block at address " +| C.prettyAddress addr |+ ""))))
+          liftIO $ C.logMessage s0 (C.msgWith { C.logLevel = C.Debug
+                                              , C.logSource = C.EventHandler "FindBlockContaining"
+                                              , C.logText = [Fmt.fmt ("Finding block at address " +| C.prettyAddress addr |+ "")]
+                                              })
           case C.containingBlocks ares addr of
             [b] -> do
               let fh = C.blockFunction b
@@ -355,8 +374,11 @@ handleCustomEvent s0 evt =
       | Just Refl <- testEquality (s0 ^. C.lNonce) archNonce -> do
           let callback b = do
                 let fh = C.blockFunction b
+                C.logMessage s0 (C.msgWith { C.logLevel = C.Debug
+                                           , C.logSource = C.EventHandler "ListBlocks"
+                                           , C.logText = [Fmt.fmt ("Pushing a block to view: " +| C.blockAddress b ||+"")]
+                                           })
                 C.sEmitEvent s0 (C.PushContext archNonce fh C.BaseRepr b)
-                C.logDiagnostic s0 C.LogDebug (Fmt.fmt ("Pushing a block to view: " +| C.blockAddress b ||+""))
                 C.sEmitEvent s0 (C.ViewBlock archNonce C.BaseRepr)
           let s1 = s0 & C.lUIMode .~ C.SomeUIMode C.BlockSelector
                       & C.lArchState . _Just . blockSelectorL .~ BS.blockSelector callback focusedListAttr blocks
@@ -379,9 +401,15 @@ handleCustomEvent s0 evt =
           let callback f = do
                 case C.functionBlocks (archState ^. C.lAnalysisResult) f of
                   [] ->
-                    C.sEmitEvent s0 (C.LogDiagnostic (Just C.LogWarning) (Fmt.fmt ("Failed to find blocks for function: " +| f ||+"")))
+                    C.logMessage s0 (C.msgWith { C.logLevel = C.Warn
+                                               , C.logSource = C.EventHandler "ListFunctions"
+                                               , C.logText = [Fmt.fmt ("Failed to find blocks for function: " +| f ||+"")]
+                                               })
                   entryBlock : _ -> do
-                    C.sEmitEvent s0 (C.LogDiagnostic (Just C.LogDebug) (Fmt.fmt ("Selecting function: " +| f ||+ "")))
+                    C.logMessage s0 (C.msgWith { C.logLevel = C.Debug
+                                               , C.logSource = C.EventHandler "ListFunctions"
+                                               , C.logText = [Fmt.fmt ("Selecting function: " +| f ||+ "")]
+                                               })
                     C.sEmitEvent s0 (C.PushContext archNonce f C.BaseRepr entryBlock)
                     C.sEmitEvent s0 (C.ViewFunction archNonce C.BaseRepr)
           let s1 = s0 & C.lUIMode .~ C.SomeUIMode C.FunctionSelector
@@ -396,17 +424,26 @@ handleCustomEvent s0 evt =
           (ctx, sessionState) <- liftIO $ C.makeContext ng (archState ^. C.irCacheL) (archState ^. C.lAnalysisResult) fh irrepr b
           let s1 = s0 & C.lArchState . _Just . C.contextL %~ C.pushContext ctx
                       & C.lArchState . _Just . C.symExStateL %~ (<> sessionState)
-          liftIO $ C.sEmitEvent s0 (C.LogDiagnostic (Just C.LogDebug) (Fmt.fmt ("Selecting block: " +| C.blockAddress b ||+ "")))
-          liftIO $ C.logDiagnostic s0 C.LogDebug (Fmt.fmt ("from function " +| C.blockFunction b ||+ ""))
+          liftIO $ C.logMessage s0 (C.msgWith { C.logLevel = C.Debug
+                                              , C.logSource = C.EventHandler "PushContext"
+                                              , C.logText = [ Fmt.fmt ("Selecting block: " +| C.blockAddress b ||+ "")
+                                                            , Fmt.fmt ("from function " +| C.blockFunction b ||+ "")
+                                                            ]})
           B.continue (C.State s1)
       | otherwise -> do
         case s0 ^. C.lArchState of
-          Nothing -> liftIO $ C.logDiagnostic s0 C.LogDebug "PushContext: no arch state"
+          Nothing -> liftIO $ C.logMessage s0 (C.msgWith { C.logText = ["No arch state"]
+                                                         , C.logLevel = C.Warn
+                                                         , C.logSource = C.EventHandler "PushContext"
+                                                         })
           Just _archState
             | Just Refl <- testEquality (s0 ^. C.lNonce) archNonce ->
               return ()
             | otherwise ->
-              liftIO $ C.logDiagnostic s0 C.LogDebug "PushContext: Nonce mismatch"
+              liftIO $ C.logMessage s0 (C.msgWith { C.logText = ["Nonce mismatch"]
+                                                  , C.logLevel = C.Warn
+                                                  , C.logSource = C.EventHandler "PushContext"
+                                                  })
         B.continue (C.State s0)
     C.ContextBack -> do
       let s1 = s0 & C.lArchState . _Just . C.contextL %~ C.contextBack
@@ -415,20 +452,22 @@ handleCustomEvent s0 evt =
       let s1 = s0 & C.lArchState . _Just . C.contextL %~ C.contextForward
       B.continue $! C.State s1
 
-    C.LogDiagnostic mLogLevel t ->
-      case mLogLevel of
-        Nothing -> B.continue $! C.State (s0 & C.lDiagnosticLog %~ (Seq.|> (mLogLevel, t)))
-        Just logLevel
-          | logLevel >= C.sDiagnosticLevel s0 ->
-            B.continue $! C.State (s0 & C.lDiagnosticLog %~ (Seq.|> (Just logLevel, t)))
-          | otherwise -> B.continue $! C.State s0
+    C.LogDiagnostic msg
+      | C.logLevel (C.logMsg msg) >= C.sDiagnosticLevel s0 ->
+        B.continue $! C.State (s0 & C.lLogStore %~ C.appendLog msg)
+      | otherwise -> B.continue $! C.State s0
 
     C.DescribeKeys -> do
       withBaseMode (s0 ^. C.lUIMode) $ \normalMode -> do
         let keys = C.modeKeybindings (s0 ^. C.lKeymap) (C.SomeUIMode normalMode)
-        liftIO $ C.logMessage s0 (Fmt.fmt ("Keybindings for " +| C.prettyMode normalMode |+ ":"))
-        F.forM_ keys $ \(k, C.SomeCommand cmd) -> do
-          liftIO $ C.logMessage s0 (Fmt.fmt ("  " +| PP.pretty k ||+ ": " +| C.cmdName cmd |+ ""))
+        let formatKey (k, C.SomeCommand cmd) =
+              Fmt.fmt ("  "+| PP.pretty k ||+ ": " +| C.cmdName cmd |+ "")
+        liftIO $ C.logMessage s0 (C.msgWith { C.logLevel = C.Requested
+                                            , C.logSource = C.EventHandler "DescribeKeys"
+                                            , C.logText = ( Fmt.fmt ("Keybindings for " +| C.prettyMode normalMode |+ ":")
+                                                          : map formatKey keys
+                                                          )
+                                            })
       let s1 = s0 & C.lUIMode .~ C.SomeUIMode C.Diags
       B.continue $! C.State s1
 
@@ -499,8 +538,14 @@ stateFromAnalysisResult s0 ares newDiags state uiMode = do
                    _ -> error ("No blocks in function " ++ show defFunc)
   let ng = C.sNonceGenerator s0
   ses <- C.defaultSymbolicExecutionConfig ng
-  return C.S { C.sDiagnosticLog = C.sDiagnosticLog s0 <> fmap (Nothing,) newDiags
+  let appendTextLog ls t = do
+        msg <- C.timestamp (C.msgWith { C.logText = [t], C.logSource = C.Loader })
+        return (C.appendLog msg ls)
+  nextLogStore <- F.foldlM appendTextLog (C.sLogStore s0) newDiags
+  return C.S { C.sLogStore = nextLogStore
              , C.sDiagnosticLevel = C.sDiagnosticLevel s0
+             -- FIXME: Add a way to set a log file
+             , C.sLogAction = C.logToState (C.sEventChannel s0)
              , C.sUIMode = uiMode
              , C.sAppState = state
              , C.sEmitEvent = C.sEmitEvent s0

--- a/surveyor-core/src/Surveyor/Core.hs
+++ b/surveyor-core/src/Surveyor/Core.hs
@@ -154,6 +154,7 @@ module Surveyor.Core (
   SCL.LogAction,
   SCL.logToFile,
   SCL.logToState,
+  SCL.defaultLogFile,
   -- ** Log Store
   SCL.LogStore,
   SCL.appendLog,

--- a/surveyor-core/src/Surveyor/Core.hs
+++ b/surveyor-core/src/Surveyor/Core.hs
@@ -150,7 +150,24 @@ module Surveyor.Core (
   K.modeKeybindings,
   K.lookupKeyCommand,
   -- * Logging
-  CE.LogLevel(..),
+  -- ** Log Actions
+  SCL.LogAction,
+  SCL.logToFile,
+  SCL.logToState,
+  -- ** Log Store
+  SCL.LogStore,
+  SCL.appendLog,
+  SCL.takeLogs,
+  -- ** Log Messages
+  SCL.Source(..),
+  SCL.Severity(..),
+  SCL.LogMessage(..),
+  SCL.msgWith,
+  SCL.Timestamped,
+  SCL.Timestamp,
+  SCL.timestamp,
+  SCL.logTime,
+  SCL.logMsg,
   -- * Defaults
   defaultKeymap
   ) where
@@ -172,6 +189,7 @@ import qualified Surveyor.Core.Events as CE
 import qualified Surveyor.Core.IRRepr as IR
 import qualified Surveyor.Core.Keymap as K
 import qualified Surveyor.Core.Loader as CL
+import qualified Surveyor.Core.Logging as SCL
 import qualified Surveyor.Core.Mode as M
 import qualified Surveyor.Core.OperandList as OL
 import           Surveyor.Core.State

--- a/surveyor-core/src/Surveyor/Core/Commands.hs
+++ b/surveyor-core/src/Surveyor/Core/Commands.hs
@@ -28,6 +28,8 @@ module Surveyor.Core.Commands (
   initializeSymbolicExecutionC,
   beginSymbolicExecutionSetupC,
   startSymbolicExecutionC,
+  setLogFileC,
+  disableFileLoggingC,
   allCommands
   ) where
 
@@ -79,6 +81,8 @@ allCommands =
   , C.SomeCommand initializeSymbolicExecutionC
   , C.SomeCommand beginSymbolicExecutionSetupC
   , C.SomeCommand startSymbolicExecutionC
+  , C.SomeCommand setLogFileC
+  , C.SomeCommand disableFileLoggingC
   ]
 
 exitC :: forall s st . Command s st '[]
@@ -217,6 +221,26 @@ contextForwardC =
     callback :: Callback s st '[]
     callback = \customEventChan _ PL.Nil ->
       C.writeChan customEventChan ContextForward
+
+setLogFileC :: forall s st . Command s st '[AR.FilePathType]
+setLogFileC =
+  C.Command "set-log-file" doc names rep callback (const True)
+  where
+    doc = "Log to a file (in addition to the internal buffer); if the provided filepath is the empty string, the default is used (~/.cache/surveyor.log)"
+    names = C.Const "file-name" PL.:< PL.Nil
+    rep = AR.FilePathTypeRepr PL.:< PL.Nil
+    callback :: Callback s st '[AR.FilePathType]
+    callback = \customEventChan _ (AR.FilePathArgument filepath PL.:< PL.Nil) ->
+      C.writeChan customEventChan (SetLogFile filepath)
+
+disableFileLoggingC :: forall s st . Command s st '[]
+disableFileLoggingC =
+  C.Command "disable-file-logging" doc PL.Nil PL.Nil callback (const True)
+  where
+    doc = "Disable logging to a file, if it is enabled"
+    callback :: Callback s st '[]
+    callback = \customEventChan _ _ ->
+      C.writeChan customEventChan DisableFileLogging
 
 loadFileC :: forall s st . Command s st '[AR.FilePathType]
 loadFileC =

--- a/surveyor-core/src/Surveyor/Core/Events.hs
+++ b/surveyor-core/src/Surveyor/Core/Events.hs
@@ -86,6 +86,8 @@ data Events s st where
   EchoText :: !T.Text -> Events s st
   ResetEchoArea :: Events s st
   LogDiagnostic :: !(CLM.Timestamped CLM.LogMessage) -> Events s st
+  SetLogFile :: FilePath -> Events s st
+  DisableFileLogging :: Events s st
   DescribeKeys :: Events s st
 
   -- UI Modes

--- a/surveyor-core/src/Surveyor/Core/Events.hs
+++ b/surveyor-core/src/Surveyor/Core/Events.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE PolyKinds #-}
-module Surveyor.Core.Events ( Events(..), LogLevel(..) ) where
+module Surveyor.Core.Events ( Events(..) ) where
 
 import qualified Control.Exception as X
 import qualified Control.NF as NF
@@ -22,13 +22,7 @@ import qualified Surveyor.Core.SymbolicExecution.Config as SE
 import qualified Surveyor.Core.SymbolicExecution.Session as CSS
 import qualified Surveyor.Core.SymbolicExecution.State as SES
 import qualified Surveyor.Core.IRRepr as IR
-
-data LogLevel = LogDebug
-              | LogInfo
-              | LogWarning
-              | LogError
-              | LogFatal
-              deriving (Show, Eq, Ord)
+import qualified Surveyor.Core.Logging.Message as CLM
 
 data Events s st where
   -- Loading events
@@ -91,7 +85,7 @@ data Events s st where
   DescribeCommand :: (C.CommandLike cmd) => C.SomeCommand cmd -> Events s st
   EchoText :: !T.Text -> Events s st
   ResetEchoArea :: Events s st
-  LogDiagnostic :: Maybe LogLevel -> !T.Text -> Events s st
+  LogDiagnostic :: !(CLM.Timestamped CLM.LogMessage) -> Events s st
   DescribeKeys :: Events s st
 
   -- UI Modes

--- a/surveyor-core/src/Surveyor/Core/Logging.hs
+++ b/surveyor-core/src/Surveyor/Core/Logging.hs
@@ -97,7 +97,10 @@ logToFile fp = do
 -- This uses the XDG spec on Unix systems to identify a suitable user-local
 -- logging directory.
 defaultLogFile :: IO FilePath
-defaultLogFile = (</> "surveyor.log") <$> SD.getXdgDirectory SD.XdgData "surveyor"
+defaultLogFile = do
+  logDir <- SD.getXdgDirectory SD.XdgData "surveyor"
+  SD.createDirectoryIfMissing True logDir
+  return (logDir </> "surveyor.log")
 
 -- | This worker runs in an asynchronous thread to flush the message queue to disk
 writeMessageToFile :: PP.Pretty a => IO.Handle -> CC.Chan a -> IO ()

--- a/surveyor-core/src/Surveyor/Core/Logging.hs
+++ b/surveyor-core/src/Surveyor/Core/Logging.hs
@@ -1,0 +1,90 @@
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+-- | This module encapsulates all of the logic for managing and rotating logs
+--
+-- It is currently based on the Lumberjack package.
+module Surveyor.Core.Logging (
+  -- * Log actions
+  LogAction,
+  logToFile,
+  logToState,
+  logMessage,
+  -- * Log messages
+  CLM.Source(..),
+  CLM.Severity(..),
+  CLM.LogMessage(..),
+  CLM.msgWith,
+  CLM.Timestamped,
+  CLM.Timestamp,
+  CLM.logTime,
+  CLM.logMsg,
+  CLM.timestamp,
+  -- * Log management
+  LogStore,
+  takeLogs,
+  appendLog
+  ) where
+
+import qualified Control.Concurrent as CC
+import qualified Control.Concurrent.Async as A
+import qualified Data.Sequence as Seq
+import qualified Data.Text.IO as TIO
+import qualified Data.Text.Prettyprint.Doc as PP
+import qualified Data.Text.Prettyprint.Doc.Render.Text as PPT
+import qualified Lumberjack as L
+import           Numeric.Natural ( Natural )
+import qualified System.IO as IO
+
+import qualified Surveyor.Core.Chan as SCC
+import qualified Surveyor.Core.Events as SCE
+import qualified Surveyor.Core.Logging.Message as CLM
+
+newtype LogAction = LogAction (L.LogAction IO CLM.LogMessage)
+  deriving (Monoid, Semigroup)
+
+logMessage :: LogAction -> CLM.LogMessage -> IO ()
+logMessage (LogAction a) msg = L.writeLog a msg
+
+-- | The data structure in which in-memory logs are stored
+--
+-- It could be bounded by a configurable buffer size.
+data LogStore =
+  LogStore { logs :: !(Seq.Seq (CLM.Timestamped CLM.LogMessage))
+           }
+
+-- | Take the @n@ most recent logs
+takeLogs :: Natural -> LogStore -> Seq.Seq (CLM.Timestamped CLM.LogMessage)
+takeLogs n (LogStore ls) = Seq.drop (Seq.length ls - fromIntegral n) ls
+
+instance Semigroup LogStore where
+  ls1 <> ls2 = LogStore (logs ls1 <> logs ls2)
+
+instance Monoid LogStore where
+  mempty = emptyLogStore
+
+emptyLogStore :: LogStore
+emptyLogStore = LogStore { logs = mempty }
+
+appendLog :: CLM.Timestamped CLM.LogMessage -> LogStore -> LogStore
+appendLog msg st = st { logs = logs st Seq.|> msg }
+
+logToState :: SCC.Chan (SCE.Events s st) -> LogAction
+logToState chan =
+  LogAction (CLM.addTimestamp logAction)
+  where
+    logAction = L.LogAction (\msg -> SCC.writeChan chan (SCE.LogDiagnostic msg))
+
+logToFile :: FilePath -> IO LogAction
+logToFile fp = do
+  c <- CC.newChan
+  _ <- A.async $ do
+    IO.withFile fp IO.AppendMode $ \h ->
+      writeMessageToFile h c
+  let logAction = L.LogAction (CC.writeChan c)
+  return (LogAction (CLM.addTimestamp logAction))
+
+writeMessageToFile :: PP.Pretty a => IO.Handle -> CC.Chan a -> IO ()
+writeMessageToFile hdl c = do
+  msg <- CC.readChan c
+  let doc = PP.layoutSmart PP.defaultLayoutOptions (PP.pretty msg)
+  TIO.hPutStrLn hdl (PPT.renderStrict doc)
+  writeMessageToFile hdl c

--- a/surveyor-core/src/Surveyor/Core/Logging/Message.hs
+++ b/surveyor-core/src/Surveyor/Core/Logging/Message.hs
@@ -1,0 +1,129 @@
+-- | This module defines the types of messages that we log in surveyor
+--
+--  This is a separate module from the main logging module
+--  (Surveyor.Core.Logging) to break an import cycle, as we need to refer to the
+--  log message type from both Surveyor.Core.Logging and Surveyor.Core.Events.
+--
+--  It uses a custom log type compared to lumberjack to split out the timestamp
+--  and log message into separate types with a different approach to adding
+--  timestamps.
+module Surveyor.Core.Logging.Message (
+  Source(..),
+  Severity(..),
+  LogMessage(..),
+  msgWith,
+  -- * Timestamp support
+  Timestamped,
+  logTime,
+  logMsg,
+  Timestamp,
+  addTimestamp,
+  timestamp
+  ) where
+
+import           Control.Monad.IO.Class ( MonadIO, liftIO )
+import qualified Data.Functor.Contravariant as DFC
+import qualified Data.Text as T
+import qualified Data.Text.Prettyprint.Doc as PP
+import qualified Data.Time.Clock as TC
+import qualified Data.Time.Format as TF
+import qualified Lumberjack as L
+
+data Source = Unspecified
+            | EventHandler !T.Text
+            | CommandCallback !T.Text
+            | EchoAreaUpdate
+            | Loader
+  deriving (Eq, Ord, Show)
+
+data Severity = Debug
+              | Info
+              | Warn
+              | Error
+              | Requested
+              -- ^ Output explicitly requested by the user, never to be suppressed
+              deriving (Eq, Ord, Show)
+
+newtype Timestamp = Timestamp (TC.UTCTime)
+  deriving (Eq, Ord, Show)
+
+data Timestamped a =
+  Timestamped { logTime :: !Timestamp
+              , logMsg :: !a
+              }
+
+data LogMessage =
+  LogMessage { logLevel :: !Severity
+             , logSource :: !Source
+             , logText :: [T.Text]
+             }
+
+msgWith :: LogMessage
+msgWith = LogMessage { logLevel = Debug
+                     , logText = mempty
+                     , logSource = Unspecified
+                     }
+
+addTimestamp :: (MonadIO m) => L.LogAction m (Timestamped msg) -> L.LogAction m msg
+addTimestamp a = L.LogAction $ \msg -> do
+  t <- Timestamp <$> liftIO TC.getCurrentTime
+  L.writeLog (DFC.contramap (Timestamped t) a) msg
+
+timestamp :: (MonadIO m) => msg -> m (Timestamped msg)
+timestamp msg = do
+  t <- Timestamp <$> liftIO TC.getCurrentTime
+  return (Timestamped t msg)
+
+prettySource :: Source -> PP.Doc ann
+prettySource ctx =
+  case ctx of
+    Unspecified -> PP.emptyDoc
+    Loader -> PP.pretty "Loader"
+    EventHandler evt -> PP.pretty "Event" <> PP.brackets (PP.pretty evt)
+    CommandCallback cmd -> PP.pretty "Command" <> PP.brackets (PP.pretty cmd)
+    EchoAreaUpdate -> PP.pretty "Echo"
+
+prettySeverity :: Severity -> PP.Doc ann
+prettySeverity sev =
+  case sev of
+    Debug -> PP.pretty "Debug"
+    Info -> PP.pretty "Info"
+    Warn -> PP.pretty "Warn"
+    Error -> PP.pretty "Error"
+    Requested -> PP.emptyDoc
+
+prettyTime :: TC.UTCTime -> PP.Doc ann
+prettyTime t =
+  PP.hcat [ PP.pretty (TF.formatTime TF.defaultTimeLocale "%Z-%F:%H:" t)
+          , PP.pretty (TF.formatTime TF.defaultTimeLocale "%M:%S" t)
+          , PP.pretty (take 4 (TF.formatTime TF.defaultTimeLocale ".%q" t))
+          ]
+
+instance PP.Pretty Timestamp where
+  pretty (Timestamp ts) = prettyTime ts
+
+prettyTimestamped :: (a -> PP.Doc ann) -> Timestamped a -> PP.Doc ann
+prettyTimestamped pp ts =
+  PP.hsep [ PP.pretty (logTime ts)
+          , pp (logMsg ts)
+          ]
+
+prettyLogMessage :: LogMessage -> PP.Doc ann
+prettyLogMessage lm =
+  case logText lm of
+    [] -> PP.hsep [ prettySeverity (logLevel lm)
+                  , prettySource (logSource lm)
+                  ]
+    [msg] -> PP.hsep [ prettySeverity (logLevel lm)
+                     , prettySource (logSource lm)
+                     , PP.pretty msg
+                     ]
+    msgLines ->
+      let pfx = prettySeverity (logLevel lm) PP.<+> prettySource (logSource lm)
+      in pfx PP.<+> PP.align (PP.vsep (map PP.pretty msgLines))
+
+instance PP.Pretty LogMessage where
+  pretty = prettyLogMessage
+
+instance (PP.Pretty a) => PP.Pretty (Timestamped a) where
+  pretty = prettyTimestamped PP.pretty

--- a/surveyor-core/surveyor-core.cabal
+++ b/surveyor-core/surveyor-core.cabal
@@ -42,6 +42,8 @@ library
                        Surveyor.Core.Loader
                        Surveyor.Core.Loader.PPCConfig
                        Surveyor.Core.Loader.RenovateAnalysis
+                       Surveyor.Core.Logging
+                       Surveyor.Core.Logging.Message
                        Surveyor.Core.Mode
                        Surveyor.Core.OperandList
                        Surveyor.Core.State
@@ -62,6 +64,7 @@ library
                        pretty,
                        ansi-wl-pprint,
                        process,
+                       time >= 1.6 && < 1.11,
                        split >= 0.2 && < 0.3,
                        lens >= 4.15 && < 5,
                        generic-lens >= 0.5.1.0 && < 1.3,
@@ -70,6 +73,7 @@ library
                        megaparsec >= 7 && < 9,
                        IntervalMap >= 0.6 && < 0.7,
                        regex-tdfa >= 1 && < 2,
+                       lumberjack >= 0.1 && < 0.2,
                        vty,
                        elf-edit,
                        haggle,

--- a/surveyor-core/surveyor-core.cabal
+++ b/surveyor-core/surveyor-core.cabal
@@ -55,6 +55,7 @@ library
                        containers,
                        async,
                        exceptions,
+                       directory >= 1.3 && < 1.4,
                        bytestring,
                        text,
                        fmt >= 0.6 && < 0.7,


### PR DESCRIPTION
This regularizes the logging infrastructure to not emit messages and use the
logging API directly.  This will let us more easily support sending logs to
files as well as the in-memory buffer.

This uses a custom log message type modeled after the one from lumberjack.  It
attempts to hide the fact that it uses lumberjack to make future updates to call
sites a bit easier (hopefully).