### PR TITLE
WIP Start implementing a Crucible execution feature

### DIFF
--- a/.github/workflows/ci-matrix.yml
+++ b/.github/workflows/ci-matrix.yml
@@ -19,10 +19,7 @@ jobs:
       matrix:
         ghc: ['8.6.5', '8.8.3']
         cabal: ['3.2.0.0']
-        os: [ubuntu-latest, macOS-latest]
-        exclude:
-          - os: macOS-latest
-            ghc: 8.6.5
+        os: [ubuntu-latest]
 
     name: GHC ${{ matrix.ghc }} on ${{ matrix.os }} surveyor
 

--- a/cabal.project.dist
+++ b/cabal.project.dist
@@ -1,5 +1,6 @@
 packages: surveyor-core
           surveyor-brick
+          crux-dbg
           deps/llvm-pretty
           deps/llvm-pretty-bc-parser
           deps/elf-edit
@@ -11,6 +12,7 @@ packages: surveyor-core
           deps/crucible/crucible-llvm
           deps/crucible/crucible-jvm
           deps/crucible/crux
+          deps/crucible/crux-llvm
           deps/dismantle/dismantle-tablegen
           deps/dismantle/dismantle-ppc
           deps/dismantle/dismantle-arm-xml

--- a/crux-dbg/CHANGELOG.md
+++ b/crux-dbg/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Revision history for crux-dbg
+
+## 0.1.0.0 -- YYYY-mm-dd
+
+* First version. Released on an unsuspecting world.

--- a/crux-dbg/LICENSE
+++ b/crux-dbg/LICENSE
@@ -1,0 +1,30 @@
+Copyright (c) 2020, Tristan Ravitch
+
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+
+    * Redistributions in binary form must reproduce the above
+      copyright notice, this list of conditions and the following
+      disclaimer in the documentation and/or other materials provided
+      with the distribution.
+
+    * Neither the name of Tristan Ravitch nor the names of other
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/crux-dbg/Setup.hs
+++ b/crux-dbg/Setup.hs
@@ -1,0 +1,2 @@
+import Distribution.Simple
+main = defaultMain

--- a/crux-dbg/crux-dbg.cabal
+++ b/crux-dbg/crux-dbg.cabal
@@ -1,0 +1,48 @@
+cabal-version:       >=1.10
+name:                crux-dbg
+version:             0.1.0.0
+synopsis:            A static verifier and symbolic debugger
+description:         This tool is a static assertion checker, like crux-llvm, but supports some additional primitives
+                     for interactive debugging (e.g., breakpoints).  When a breakpoint is triggered, it brings up an
+                     interactive UI for state exploration.
+-- bug-reports:
+license:             BSD3
+license-file:        LICENSE
+author:              Tristan Ravitch
+maintainer:          tristan@galois.com
+-- copyright:
+category:            Verification
+build-type:          Simple
+extra-source-files:  CHANGELOG.md
+
+library
+  exposed-modules:     Crux.Debug.Config
+                       Crux.Debug.LLVM
+  build-depends:       base >=4.10 && <5,
+                       containers,
+                       text,
+                       exceptions,
+                       lens,
+                       parameterized-utils,
+                       llvm-pretty,
+                       llvm-pretty-bc-parser,
+                       crucible,
+                       crucible-llvm,
+                       crux,
+                       crux-llvm,
+                       surveyor-core,
+                       surveyor-brick
+  hs-source-dirs:      src
+  default-language:    Haskell2010
+  ghc-options:         -Wall -Wcompat
+
+executable crux-dbg
+  main-is:             Main.hs
+  build-depends:       base >=4.10 && <5,
+                       filepath,
+                       surveyor-brick,
+                       crux,
+                       crux-dbg
+  hs-source-dirs:      tools/crux-dbg
+  default-language:    Haskell2010
+  ghc-options:         -Wall -Wcompat -rtsopts -threaded "-with-rtsopts=-I0"

--- a/crux-dbg/src/Crux/Debug/Config.hs
+++ b/crux-dbg/src/Crux/Debug/Config.hs
@@ -1,0 +1,47 @@
+{-# LANGUAGE ApplicativeDo #-}
+{-# LANGUAGE OverloadedStrings #-}
+module Crux.Debug.Config (
+  DebugOptions(..),
+  debugConfig
+  ) where
+
+import qualified Crux as C
+import qualified Lang.Crucible.LLVM.MemModel as CLM
+
+data DebugOptions =
+  DebugOptions { entryPoint :: Maybe String
+               , interactive :: Bool
+               , laxArithmetic :: Bool
+               , memoryOptions :: CLM.MemOptions
+               }
+
+debugConfig :: C.Config DebugOptions
+debugConfig =
+  C.Config { C.cfgFile = do
+               ep <- C.sectionMaybe "entry-point" C.fileSpec "The entry point to simulate from (defaults to 'main')"
+               int <- C.section "interactive" C.yesOrNoSpec False "Start in interactive (TUI) mode"
+               lax <- C.section "lax-arithmetic" C.yesOrNoSpec False "Turn on lax enforcement of arithmetic overflow"
+               memOpts <- do laxPtrOrd <- C.section "lax-pointer-ordering" C.yesOrNoSpec False
+                                               "Allow order comparisons between pointers from different allocation blocks"
+                             laxConstEq <-  C.section "lax-constant-equality" C.yesOrNoSpec False
+                                               "Allow equality comparisons between pointers to constant data"
+                             return CLM.MemOptions { CLM.laxPointerOrdering = laxPtrOrd
+                                                   , CLM.laxConstantEquality= laxConstEq
+                                                   }
+               return DebugOptions { entryPoint = ep
+                                   , interactive = int
+                                   , laxArithmetic = lax
+                                   , memoryOptions = memOpts
+                                   }
+           , C.cfgEnv = []
+           , C.cfgCmdLineFlag =
+             [ C.Option [] ["entry-point"] "The entry point to simulate from (defaults to 'main')"
+               $ C.ReqArg "FUNC" $ \f opts -> Right opts { entryPoint = Just f }
+             , C.Option ['i'] ["interactive"] "Start in interactive (TUI) mode"
+               $ C.NoArg $ \opts -> Right opts { interactive = True }
+             , C.Option [] ["lax-arithmetic"] "Turn on lax enforcement of arithmetic overflow"
+               $ C.NoArg $ \opts -> Right opts { laxArithmetic = True }
+             , C.Option [] ["lax-pointers"] "Turn on lax enforcement of pointer comparison rules"
+               $ C.NoArg $ \opts -> Right opts { memoryOptions = CLM.laxPointerMemOptions }
+             ]
+           }

--- a/crux-dbg/src/Crux/Debug/LLVM.hs
+++ b/crux-dbg/src/Crux/Debug/LLVM.hs
@@ -1,0 +1,207 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE ImplicitParams #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE QuasiQuotes #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE TypeApplications #-}
+module Crux.Debug.LLVM (
+  debugLLVM
+  ) where
+
+import           Control.Lens ( (^.), (&), (%~) )
+import qualified Control.Monad.Catch as CMC
+import           Control.Monad.IO.Class ( liftIO )
+import qualified Data.IORef as IOR
+import qualified Data.LLVM.BitCode as DLB
+import qualified Data.Map.Strict as Map
+import           Data.Maybe ( fromMaybe )
+import qualified Data.Parameterized.Classes as PC
+import qualified Data.Parameterized.Context as Ctx
+import qualified Data.Parameterized.NatRepr as NR
+import           Data.Parameterized.Some ( Some(..) )
+import           Data.Proxy ( Proxy(..) )
+import           Data.String ( fromString )
+import qualified Data.Text as T
+import qualified System.Exit as SE
+import qualified System.IO as IO
+import qualified Text.LLVM as TL
+
+import qualified Crux as C
+import qualified Crux.LLVM.Overrides as CLO
+import qualified Crux.Log as CL
+import qualified Crux.Model as CM
+import qualified Crux.Types as CT
+import qualified Lang.Crucible.Backend as LCB
+import qualified Lang.Crucible.CFG.Core as CCC
+import qualified Lang.Crucible.FunctionHandle as CFH
+import qualified Lang.Crucible.LLVM as LCL
+import qualified Lang.Crucible.LLVM.QQ as LCLQ
+import qualified Lang.Crucible.LLVM.Extension as CLE
+import qualified Lang.Crucible.LLVM.Globals as CLG
+import qualified Lang.Crucible.LLVM.Intrinsics as CLI
+import qualified Lang.Crucible.LLVM.MemModel as CLM
+import qualified Lang.Crucible.LLVM.Translation as CLT
+import qualified Lang.Crucible.Simulator as LCS
+import qualified Lang.Crucible.Simulator.ExecutionTree as LCSET
+import qualified Lang.Crucible.Simulator.GlobalState as LCSG
+import qualified Lang.Crucible.Simulator.Profiling as LCSP
+import qualified Lang.Crucible.Types as LCT
+
+import qualified Crux.Debug.Config as CDC
+import qualified Surveyor.Brick as SB
+import qualified Surveyor.Core as SC
+
+breakpointOverrides :: ( LCB.IsSymInterface sym
+                       , CLM.HasLLVMAnn sym
+                       , CLM.HasPtrWidth wptr
+                       , wptr ~ CLE.ArchWidth arch
+                       )
+                    => [CLI.OverrideTemplate (CT.Model sym) sym arch rtp l a]
+breakpointOverrides =
+  [ CLI.basic_llvm_override $ [LCLQ.llvmOvr| void @crucible_breakpoint() |]
+       do_breakpoint
+  ]
+
+
+data LLVMException = BitcodeParseException FilePath DLB.Error
+                   | MemoryMissingFromGlobalVars
+                   | forall w. UnsupportedX86BitWidth (NR.NatRepr w)
+                   | MissingEntryPoint String
+                   | EntryPointHasArguments
+
+deriving instance Show LLVMException
+
+instance CMC.Exception LLVMException
+
+parseLLVM :: FilePath -> IO TL.Module
+parseLLVM bcFilePath = do
+  eres <- DLB.parseBitCodeFromFile bcFilePath
+  case eres of
+    Right m -> return m
+    Left err -> CMC.throwM (BitcodeParseException bcFilePath err)
+
+setupSimCtx :: ( CLO.ArchOk arch
+               , LCB.IsSymInterface sym
+               , CLM.HasLLVMAnn sym
+               )
+            => IO.Handle
+            -> CFH.HandleAllocator
+            -> sym
+            -> CLM.MemOptions
+            -> CLT.LLVMContext arch
+            -> LCS.SimContext (CT.Model sym) sym (CLE.LLVM arch)
+setupSimCtx outHdl halloc sym memOpts llvmCtx =
+  LCS.initSimContext sym
+                     CLI.llvmIntrinsicTypes
+                     halloc
+                     outHdl
+                     (LCS.fnBindingsFromList [])
+                     (LCL.llvmExtensionImpl memOpts)
+                     CM.emptyModel
+     & LCS.profilingMetrics %~ Map.union (llvmMetrics llvmCtx)
+
+debugLLVM :: (?outputConfig :: CL.OutputConfig) => C.CruxOptions -> CDC.DebugOptions -> FilePath -> IO SE.ExitCode
+debugLLVM cruxOpts dbgOpts bcFilePath = do
+  res <- C.runSimulator cruxOpts (simulateLLVMWithDebug cruxOpts dbgOpts bcFilePath)
+  C.postprocessSimResult cruxOpts res
+
+simulateLLVMWithDebug :: C.CruxOptions -> CDC.DebugOptions -> FilePath -> C.SimulatorCallback
+simulateLLVMWithDebug _cruxOpts dbgOpts bcFilePath = C.SimulatorCallback $ \sym _maybeOnline -> do
+  llvmModule <- parseLLVM bcFilePath
+  halloc <- CFH.newHandleAllocator
+
+  let ?laxArith = CDC.laxArithmetic dbgOpts
+  Some translation <- CLT.translateModule halloc llvmModule
+
+  let llvmCtx = translation ^. CLT.transContext
+
+  CLT.llvmPtrWidth llvmCtx $ \ptrW -> CLM.withPtrWidth ptrW $ do
+    bbMapRef <- IOR.newIORef Map.empty
+    let ?lc = llvmCtx ^. CLT.llvmTypeCtx
+    let ?badBehaviorMap = bbMapRef
+    let outHdl = ?outputConfig ^. CL.outputHandle
+    let simCtx = setupSimCtx outHdl halloc sym (CDC.memoryOptions dbgOpts) llvmCtx
+    mem <- CLG.populateAllGlobals sym (CLT.globalInitMap translation) =<< CLG.initializeAllMemory sym llvmCtx llvmModule
+    let globSt = LCL.llvmGlobals llvmCtx mem
+    let initSt = LCS.InitialState simCtx globSt LCS.defaultAbortHandler LCT.UnitRepr $ do
+          LCS.runOverrideSim LCT.UnitRepr $ do
+            registerFunctions llvmModule translation
+            checkEntryPoint (fromMaybe "main" (CDC.entryPoint dbgOpts)) (CLT.cfgMap translation)
+    case CLT.llvmArch llvmCtx of
+      CLE.X86Repr rep
+        | Just PC.Refl <- PC.testEquality rep (NR.knownNat @64) -> do
+          let llvmCon ng nonce hdlAlloc =
+                case SC.llvmAnalysisResultFromModule ng nonce hdlAlloc llvmModule (Some translation) of
+                  SC.SomeResult ares -> return ares
+          let debuggerConfig = SB.DebuggerConfig (Proxy @SC.LLVM) (Proxy @(SC.CrucibleExt SC.LLVM)) llvmCon
+          let debugger = SB.debuggerFeature debuggerConfig
+          return (C.RunnableStateWithExtensions initSt [debugger])
+        | otherwise -> CMC.throwM (UnsupportedX86BitWidth rep)
+
+do_breakpoint :: LCS.GlobalVar CLM.Mem
+              -> sym
+              -> Ctx.Assignment (LCS.RegEntry sym) Ctx.EmptyCtx
+              -> LCS.OverrideSim (CT.Model sym) sym (CLI.LLVM arch) r args ret ()
+do_breakpoint _gv _sym Ctx.Empty = return ()
+
+checkEntryPoint :: ( CLO.ArchOk arch
+                   , CL.Logs
+                   )
+                => String
+                -> CLT.ModuleCFGMap arch
+                -> LCS.OverrideSim (CT.Model sym) sym (CLI.LLVM arch) r args ret ()
+checkEntryPoint nm mp =
+  case Map.lookup (fromString nm) mp of
+    Nothing -> CMC.throwM (MissingEntryPoint nm)
+    Just (_, CCC.AnyCFG anyCFG) ->
+      case CCC.cfgArgTypes anyCFG of
+        Ctx.Empty -> do
+          liftIO $ CL.say "crux-dbg" ("Simulating from entry point " ++ show nm)
+          _ <- LCS.callCFG anyCFG LCS.emptyRegMap
+          return ()
+        _ -> CMC.throwM EntryPointHasArguments
+
+registerFunctions :: ( CLO.ArchOk arch
+                     , LCB.IsSymInterface sym
+                     , CLM.HasLLVMAnn sym
+                     )
+                  => TL.Module
+                  -> CLT.ModuleTranslation arch
+                  -> LCS.OverrideSim (CT.Model sym) sym (CLI.LLVM arch) r args ret ()
+registerFunctions llvm_module mtrans =
+  do let llvm_ctx = mtrans ^. CLT.transContext
+     let ?lc = llvm_ctx ^. CLT.llvmTypeCtx
+
+     -- register the callable override functions
+     let overrides = concat [ CLO.cruxLLVMOverrides
+                            , CLO.svCompOverrides
+                            , CLO.cbmcOverrides
+                            , breakpointOverrides
+                            ]
+     CLI.register_llvm_overrides llvm_module [] overrides llvm_ctx
+
+     -- register all the functions defined in the LLVM module
+     mapM_ (LCL.registerModuleFn llvm_ctx) $ Map.elems $ CLT.cfgMap mtrans
+
+llvmMetrics :: forall arch p sym ext
+             . CLT.LLVMContext arch
+            -> Map.Map T.Text (LCSP.Metric p sym ext)
+llvmMetrics llvmCtxt =
+  Map.fromList [ ("LLVM.allocs", allocs)
+               , ("LLVM.writes", writes)
+               ]
+  where
+    allocs = LCSP.Metric $ measureMemBy CLM.memAllocCount
+    writes = LCSP.Metric $ measureMemBy CLM.memWriteCount
+
+    measureMemBy :: (CLM.MemImpl sym -> Int)
+                 -> LCS.SimState p sym ext r f args
+                 -> IO Integer
+    measureMemBy f st = do
+      let globals = st ^. LCSET.stateGlobals
+      case LCSG.lookupGlobal (CLT.llvmMemVar llvmCtxt) globals of
+        Just mem -> return $ toInteger (f mem)
+        Nothing -> CMC.throwM MemoryMissingFromGlobalVars

--- a/crux-dbg/tools/crux-dbg/Main.hs
+++ b/crux-dbg/tools/crux-dbg/Main.hs
@@ -1,0 +1,30 @@
+{-# LANGUAGE ImplicitParams #-}
+{-# LANGUAGE MultiWayIf #-}
+{-# LANGUAGE OverloadedStrings #-}
+module Main ( main ) where
+
+import qualified System.FilePath as SFP
+import qualified System.Exit as SE
+
+import qualified Crux as C
+import qualified Crux.Log as CL
+import qualified Crux.Config.Common as CCC
+import qualified Surveyor.Brick as SB
+
+import qualified Crux.Debug.Config as CDC
+import qualified Crux.Debug.LLVM as CDL
+
+main :: IO ()
+main = do
+  let outCfg = CL.defaultOutputConfig
+  let ?outputConfig = outCfg
+  C.loadOptions outCfg "crux-dbg" "0.1" CDC.debugConfig $ \(cruxOpts, dbgOpts) -> do
+    case CCC.inputFiles cruxOpts of
+      [] | CDC.interactive dbgOpts -> SB.surveyor Nothing
+         | otherwise -> error "Expected input files or interactive mode"
+      [inp] | CDC.interactive dbgOpts -> SB.surveyor (Just inp)
+            | otherwise -> do
+                let ext = SFP.takeExtension inp
+                if | ext == ".bc" -> CDL.debugLLVM cruxOpts dbgOpts inp >>= SE.exitWith
+                   | otherwise -> error ("Unsupported input file: " ++ inp)
+      _ -> error "Multiple input files are not supported"

--- a/surveyor-brick/src/Surveyor/Brick.hs
+++ b/surveyor-brick/src/Surveyor/Brick.hs
@@ -170,17 +170,15 @@ isPlainKey (C.Key k ms) =
 
 appDraw :: C.State BH.BrickUIExtension BH.BrickUIState s -> [B.Widget Names]
 appDraw (C.State s) =
-  case C.sInputFile s of
+  case C.sArchState s of
     Nothing -> drawAppShell s introText
-    Just binFileName ->
-      case C.sArchState s of
-        Nothing -> drawAppShell s introText
-        Just archState ->
-          case C.sUIMode s of
-            C.SomeMiniBuffer (C.MiniBuffer innerMode) ->
-              drawUIMode binFileName archState s innerMode
-            C.SomeUIMode mode ->
-              drawUIMode binFileName archState s mode
+    Just archState ->
+      let binFileName = fromMaybe "No Input File" (C.sInputFile s)
+      in case C.sUIMode s of
+           C.SomeMiniBuffer (C.MiniBuffer innerMode) ->
+             drawUIMode binFileName archState s innerMode
+           C.SomeUIMode mode ->
+             drawUIMode binFileName archState s mode
   where
     introText = B.str $ unlines ["Surveyor: an interactive program exploration tool"
                                 , " * Press M-x to bring up the command prompt"

--- a/surveyor-brick/src/Surveyor/Brick/Widget/SymbolicExecution.hs
+++ b/surveyor-brick/src/Surveyor/Brick/Widget/SymbolicExecution.hs
@@ -17,6 +17,7 @@ import qualified Surveyor.Brick.Widget.SymbolicExecution.Configuration as SEC
 import qualified Surveyor.Brick.Widget.SymbolicExecution.Monitor as SEM
 import qualified Surveyor.Brick.Widget.SymbolicExecution.Setup as SES
 import qualified Surveyor.Brick.Widget.SymbolicExecution.Inspect as SEI
+import qualified Surveyor.Brick.Widget.SymbolicExecution.StateExplorer as SEE
 import qualified Surveyor.Core as C
 
 
@@ -40,6 +41,7 @@ renderSymbolicExecutionManager sem@(managerState -> Some st) =
     C.Initializing {} -> SES.renderSymbolicExecutionSetup st
     C.Executing {} -> SEM.renderSymbolicExecutionMonitor st
     C.Inspecting {} -> SEI.renderSymbolicExecutionInspector st
+    C.Suspended {} -> SEE.renderSymbolicExecutionStateExplorer st
 
 handleSymbolicExecutionManagerEvent :: B.BrickEvent Names e
                                     -> SymbolicExecutionManager e arch s
@@ -59,6 +61,9 @@ handleSymbolicExecutionManagerEvent evt sem@(managerState -> Some st) =
       return sem { managerState = Some st' }
     C.Inspecting {} -> do
       st' <- SEI.handleSymbolicExecutionInspectorEvent evt st
+      return sem { managerState = Some st' }
+    C.Suspended {} -> do
+      st' <- SEE.handleSymbolicExecutionStateExplorerEvent evt st
       return sem { managerState = Some st' }
 
 

--- a/surveyor-brick/src/Surveyor/Brick/Widget/SymbolicExecution/Inspect.hs
+++ b/surveyor-brick/src/Surveyor/Brick/Widget/SymbolicExecution/Inspect.hs
@@ -12,11 +12,10 @@ import qualified Brick as B
 import           Control.Lens ( (^.) )
 import           Data.Proxy ( Proxy(..) )
 import qualified Data.Text as T
-import qualified Lang.Crucible.Backend.Online as CBO
+import qualified Lang.Crucible.Backend as CB
 import qualified Lang.Crucible.Simulator as CS
 import qualified Lang.Crucible.Simulator.ExecutionTree as CSET
 import qualified Lang.Crucible.Simulator.RegMap as MCR
-import qualified What4.Expr as WEB
 import qualified What4.Interface as WI
 
 import           Surveyor.Brick.Names ( Names(..) )
@@ -39,7 +38,7 @@ renderSymbolicExecutionInspector st =
              , renderExecResult (Proxy @arch) execResult
              ]
 
-renderExecResult :: (sym ~ CBO.OnlineBackend s solver (WEB.Flags fm))
+renderExecResult :: (CB.IsSymInterface sym)
                  => proxy arch
                  -> CSET.ExecResult (C.CruciblePersonality arch sym) sym (C.CrucibleExt arch) (CS.RegEntry sym reg)
                  -> B.Widget Names

--- a/surveyor-brick/src/Surveyor/Brick/Widget/SymbolicExecution/StateExplorer.hs
+++ b/surveyor-brick/src/Surveyor/Brick/Widget/SymbolicExecution/StateExplorer.hs
@@ -1,0 +1,44 @@
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+module Surveyor.Brick.Widget.SymbolicExecution.StateExplorer (
+  renderSymbolicExecutionStateExplorer,
+  handleSymbolicExecutionStateExplorerEvent
+  ) where
+
+import qualified Brick as B
+import           Control.Lens ( (^.) )
+import qualified Data.Text as T
+import qualified Lang.Crucible.CFG.Core as LCCC
+import qualified Lang.Crucible.Simulator.CallFrame as LCSC
+import qualified Lang.Crucible.Simulator.ExecutionTree as CSET
+
+import           Surveyor.Brick.Names ( Names(..) )
+import qualified Surveyor.Core as C
+
+-- | Render a view of the final state from symbolic execution
+--
+-- Eventually, this should provide some mechanisms for deeply inspecting the
+-- state (including arch-specific inspection of memory).
+renderSymbolicExecutionStateExplorer :: forall arch s
+                                      . C.SymbolicExecutionState arch s C.Suspend
+                                     -> B.Widget Names
+renderSymbolicExecutionStateExplorer st =
+  case st of
+    C.Suspended _surveyorSimState crucSimState ->
+      let topFrame = crucSimState ^. CSET.stateTree . CSET.actFrame
+      in case topFrame ^. CSET.gpValue of
+        LCSC.RF {} -> B.txt "Unexpected Return Frame"
+        LCSC.OF {} -> B.txt "Unexpected Override Frame"
+        LCSC.MF cf@(LCSC.CallFrame { LCSC._frameCFG = fcfg
+                                   }) ->
+          B.vBox [ B.txt "Current Function:" B.<+> B.txt (T.pack (show (LCCC.cfgHandle fcfg)))
+                 , B.txt "Current Block:" B.<+> B.txt (T.pack (show (cf ^. LCSC.frameBlockID)))
+                 ]
+
+handleSymbolicExecutionStateExplorerEvent :: B.BrickEvent Names e
+                                          -> C.SymbolicExecutionState arch s C.Suspend
+                                          -> B.EventM Names (C.SymbolicExecutionState arch s C.Suspend)
+handleSymbolicExecutionStateExplorerEvent _evt st = return st

--- a/surveyor-brick/surveyor-brick.cabal
+++ b/surveyor-brick/surveyor-brick.cabal
@@ -29,6 +29,7 @@ library
                        Surveyor.Brick.Widget.SymbolicExecution.Inspect
                        Surveyor.Brick.Widget.SymbolicExecution.Monitor
                        Surveyor.Brick.Widget.SymbolicExecution.Setup
+                       Surveyor.Brick.Widget.SymbolicExecution.StateExplorer
                        Brick.Match.Subword
                        Brick.Widget.FilterList
                        Brick.Widget.Graph

--- a/surveyor-brick/tools/surveyor/Main.hs
+++ b/surveyor-brick/tools/surveyor/Main.hs
@@ -4,7 +4,7 @@ import           Data.Monoid
 import qualified Options.Applicative as O
 import           Prelude
 
-import           Surveyor.Brick
+import qualified Surveyor.Brick as SB
 
 data Options =
   Options { oInputFile :: Maybe FilePath
@@ -26,4 +26,4 @@ main = O.execParser opts >>= mainWith
                          ]
 
 mainWith :: Options -> IO ()
-mainWith opts = surveyor (oInputFile opts)
+mainWith opts = SB.surveyor (oInputFile opts)

--- a/surveyor-core/src/Surveyor/Core.hs
+++ b/surveyor-core/src/Surveyor/Core.hs
@@ -39,6 +39,9 @@ module Surveyor.Core (
   CA.prettyParameterizedFormula,
   CA.SomeResult(..),
   CA.CruciblePersonality,
+  CA.LLVM,
+  CA.mkLLVMResult,
+  CA.llvmAnalysisResultFromModule,
   -- ** Operand lists
   OL.OperandList,
   OL.OperandListItem(..),

--- a/surveyor-core/src/Surveyor/Core.hs
+++ b/surveyor-core/src/Surveyor/Core.hs
@@ -98,6 +98,7 @@ module Surveyor.Core (
   -- ** Symbolic Execution
   SymEx.Solver(..),
   SymEx.SymbolicExecutionConfig(..),
+  SymEx.SessionID,
   SymEx.newSessionID,
   SymEx.SomeFloatModeRepr(..),
   SymEx.defaultSymbolicExecutionConfig,

--- a/surveyor-core/src/Surveyor/Core.hs
+++ b/surveyor-core/src/Surveyor/Core.hs
@@ -94,7 +94,8 @@ module Surveyor.Core (
   CCX.selectedIndex,
   -- ** Symbolic Execution
   SymEx.Solver(..),
-  SymEx.SymbolicExecutionConfig,
+  SymEx.SymbolicExecutionConfig(..),
+  SymEx.newSessionID,
   SymEx.SomeFloatModeRepr(..),
   SymEx.defaultSymbolicExecutionConfig,
   SymEx.SymbolicState(..),
@@ -107,6 +108,7 @@ module Surveyor.Core (
   SymEx.SetupArgs,
   SymEx.Execute,
   SymEx.Inspect,
+  SymEx.Suspend,
   SymEx.ExecutionProgress,
   SymEx.executionMetrics,
   SymEx.symbolicExecutionConfig,

--- a/surveyor-core/src/Surveyor/Core/Architecture.hs
+++ b/surveyor-core/src/Surveyor/Core/Architecture.hs
@@ -31,6 +31,8 @@ module Surveyor.Core.Architecture (
   MC.mkX86Result,
   J.mkInitialJVMResult,
   J.extendJVMResult,
+  LL.LLVM,
+  LL.llvmAnalysisResultFromModule,
   LL.mkLLVMResult,
   M.Macaw,
   ) where

--- a/surveyor-core/src/Surveyor/Core/Events.hs
+++ b/surveyor-core/src/Surveyor/Core/Events.hs
@@ -24,6 +24,7 @@ import           Data.Int ( Int64 )
 import           Data.Kind ( Type )
 import qualified Data.Parameterized.Nonce as PN
 import qualified Data.Text as T
+import qualified Lang.Crucible.Backend as CB
 import qualified Lang.Crucible.CFG.Core as CCC
 import qualified Lang.Crucible.Simulator.Profiling as CSP
 
@@ -95,9 +96,10 @@ data SymbolicExecutionEvent s st where
                               -> SE.SymbolicExecutionConfig s
                               -> CCC.SomeCFG (A.CrucibleExt arch) init reg
                               -> SymbolicExecutionEvent s st
-  StartSymbolicExecution :: PN.Nonce s arch
+  StartSymbolicExecution :: (CB.IsSymInterface sym)
+                         => PN.Nonce s arch
                          -> A.AnalysisResult arch s
-                         -> SES.SymbolicState arch s solver fm init reg
+                         -> SES.SymbolicState arch s sym init reg
                          -> SymbolicExecutionEvent s st
   ReportSymbolicExecutionMetrics :: CSS.SessionID s -> CSP.Metrics I.Identity -> SymbolicExecutionEvent s st
 

--- a/surveyor-core/src/Surveyor/Core/SymbolicExecution.hs
+++ b/surveyor-core/src/Surveyor/Core/SymbolicExecution.hs
@@ -129,8 +129,9 @@ data SymbolicExecutionState arch s (k :: SymExK) where
                                 (CA.CrucibleExt arch)
                                 (CS.RegEntry sym reg)
              -> SymbolicExecutionState arch s Inspect
-  Suspended :: (CB.IsSymInterface sym)
+  Suspended :: (CB.IsSymInterface sym, ext ~ CA.CrucibleExt arch, CA.Architecture arch s)
             => SymbolicState arch s sym init reg
+            -> CSET.SimState p sym ext rtp f a
             -> SymbolicExecutionState arch s Suspend
 
 instance NFData (SymbolicExecutionState arch s k) where
@@ -142,7 +143,7 @@ instance NFData (SymbolicExecutionState arch s k) where
         symState `seq` ()
       Executing progress -> progress `deepseq` ()
       Inspecting metrics symState res -> metrics `seq` symState `seq` res `seq` ()
-      Suspended symState -> symState `seq` ()
+      Suspended symState _ -> symState `seq` ()
 
 -- | A wrapper around all of the dynamically updatable symbolic execution state
 --
@@ -216,7 +217,7 @@ symbolicExecutionConfig s =
     Initializing s' -> symbolicConfig s'
     Executing s' -> executionConfig s'
     Inspecting _ s' _ -> symbolicConfig s'
-    Suspended s' -> symbolicConfig s'
+    Suspended s' _ -> symbolicConfig s'
 
 symbolicSessionID :: SymbolicExecutionState arch s k -> SessionID s
 symbolicSessionID s = symbolicExecutionConfig s L.^. sessionID

--- a/surveyor-core/src/Surveyor/Core/SymbolicExecution/State.hs
+++ b/surveyor-core/src/Surveyor/Core/SymbolicExecution/State.hs
@@ -7,20 +7,17 @@ module Surveyor.Core.SymbolicExecution.State (
 
 import qualified Data.Parameterized.Context as Ctx
 import qualified Lang.Crucible.Backend as CB
-import qualified Lang.Crucible.Backend.Online as CBO
 import qualified Lang.Crucible.CFG.Core as CCC
 import qualified Lang.Crucible.Simulator as CS
-import qualified What4.Expr.Builder as WEB
-import qualified What4.Protocol.Online as WPO
 
 import qualified Surveyor.Core.Architecture as CA
 import           Surveyor.Core.SymbolicExecution.Config
 
-data SymbolicState arch s solver fm init reg =
+data SymbolicState arch s sym init reg =
   SymbolicState { symbolicConfig :: SymbolicExecutionConfig s
-                , symbolicBackend :: CBO.OnlineBackend s solver (WEB.Flags fm)
+                , symbolicBackend :: sym
                 , someCFG :: CCC.SomeCFG (CA.CrucibleExt arch) init reg
-                , symbolicRegs :: Ctx.Assignment (CS.RegEntry (CBO.OnlineBackend s solver (WEB.Flags fm))) init
-                , symbolicGlobals :: CS.SymGlobalState (CBO.OnlineBackend s solver (WEB.Flags fm))
-                , withSymConstraints :: forall a . ((WPO.OnlineSolver s solver, CB.IsSymInterface (CBO.OnlineBackend s solver (WEB.Flags fm))) => a) -> a
+                , symbolicRegs :: Ctx.Assignment (CS.RegEntry sym) init
+                , symbolicGlobals :: CS.SymGlobalState sym
+                , withSymConstraints :: forall a . (CB.IsSymInterface sym) => a -> a
                 }


### PR DESCRIPTION
This creates an initial state that currently always interrupts Crucible on every
step to spawn Surveyor.

That is obviously too aggressive, but it is an experiment in making sure that it
is possible to implement all of the necessary data structures.

It looks like we can, largely.  There are still some interesting questions to
answer about deconstructing the suspended state to populate e.g., the current
CFG.

We also need to be more discriminating on when we trigger it.  We could trigger
on any call to the breakpoint construct.  That would make sense if the
breakpoint had no arguments.  If there was a conditional breakpoint, we would
need to actually evaluate it.  That might be better implemented via an
override (but most of the same code would still be useful for converting a
"live" symbolic execution state into surveyor).

The execution feature could even be made programmable with a predicate over
Crucible states that indicated when to fire.