### PR TITLE
Tr/reg value viewer

### DIFF
--- a/crux-dbg/crux-dbg.cabal
+++ b/crux-dbg/crux-dbg.cabal
@@ -26,6 +26,7 @@ library
                        parameterized-utils,
                        llvm-pretty,
                        llvm-pretty-bc-parser,
+                       what4,
                        crucible,
                        crucible-llvm,
                        crux,

--- a/crux-dbg/include/crucible.h
+++ b/crux-dbg/include/crucible.h
@@ -1,0 +1,49 @@
+#ifndef CRUCIBLE_H
+#define CRUCIBLE_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif //__cplusplus
+
+#include <stdbool.h>
+#include <stdint.h>
+#include <stddef.h>
+
+// Halt the symbolic execution and drop into a debugger with a named breakpoint
+//
+// The varargs can be any expressions that are desirable to inspect in a debugging context
+void crucible_breakpoint(const char* name, ...);
+void crucible_assume(uint8_t x, const char *file, int line);
+void crucible_assert(uint8_t x, const char *file, int line);
+
+int8_t   crucible_int8_t   (const char *name);
+int16_t  crucible_int16_t  (const char *name);
+int32_t  crucible_int32_t  (const char *name);
+int64_t  crucible_int64_t  (const char *name);
+float    crucible_float    (const char *name);
+double   crucible_double   (const char *name);
+
+size_t   crucible_size_t   (const char *name);
+
+// Allocate a string of fixed length with symbolic contents
+//
+// The string has @max_len@ symbolic bytes plus a fixed NUL terminator.  Each
+// character is unconstrained and may also be NUL, allowing for verification of
+// algorithms over strings up to a certain length.
+//
+// The string contents are read-only.
+const char* crucible_string(const char *name, size_t max_len);
+
+#define crucible_uint8_t(n)  ((uint8_t)crucible_int8_t(n))
+#define crucible_uint16_t(n)  ((uint16_t)crucible_int16_t(n))
+#define crucible_uint32_t(n)  ((uint32_t)crucible_int32_t(n))
+#define crucible_uint64_t(n)  ((uint64_t)crucible_int64_t(n))
+
+#define assuming(e) crucible_assume(e, __FILE__, __LINE__)
+#define check(e) crucible_assert(e, __FILE__, __LINE__)
+
+#ifdef __cplusplus
+}
+#endif //__cplusplus
+
+#endif

--- a/crux-dbg/src/Crux/Debug/LLVM.hs
+++ b/crux-dbg/src/Crux/Debug/LLVM.hs
@@ -29,6 +29,7 @@ import qualified Data.Text as T
 import qualified System.Exit as SE
 import qualified System.IO as IO
 import qualified Text.LLVM as TL
+import qualified What4.Expr.Builder as WEB
 
 import qualified Crux as C
 import qualified Crux.LLVM.Overrides as CLO
@@ -138,7 +139,7 @@ simulateLLVMWithDebug _cruxOpts dbgOpts bcFilePath = C.SimulatorCallback $ \sym 
                 case SC.llvmAnalysisResultFromModule ng nonce hdlAlloc llvmModule (Some translation) of
                   SC.SomeResult ares -> return ares
           let debuggerConfig = SB.DebuggerConfig (Proxy @SC.LLVM) (Proxy @(SC.CrucibleExt SC.LLVM)) llvmCon
-          let debugger = SB.debuggerFeature debuggerConfig
+          let debugger = SB.debuggerFeature debuggerConfig (WEB.exprCounter sym)
           return (C.RunnableStateWithExtensions initSt [debugger])
         | otherwise -> CMC.throwM (UnsupportedX86BitWidth rep)
 

--- a/surveyor-brick/src/Surveyor/Brick.hs
+++ b/surveyor-brick/src/Surveyor/Brick.hs
@@ -356,7 +356,8 @@ stateFromContext ng mkAnalysisResult chan simState bp = do
                                   , C.symbolicRegs = error "Initial symbolic regs"
                                   }
       ctxStk <- contextStackFromState ng tc0 ares sesID simState fcfg
-      let symbolicExecutionState = C.Suspended symSt simState (Just bp)
+      -- NOTE: This can throw an exception, but that is fine: the TUI is not yet up
+      symbolicExecutionState <- C.suspendedState symSt simState (Just bp)
       let uiState = SBE.BrickUIState { SBE.sBlockSelector = BS.emptyBlockSelector
                                      , SBE.sBlockViewers = MapF.fromList blockViewers
                                      , SBE.sFunctionViewer = MapF.fromList funcViewers

--- a/surveyor-brick/src/Surveyor/Brick/Names.hs
+++ b/surveyor-brick/src/Surveyor/Brick/Names.hs
@@ -22,4 +22,5 @@ data Names = DiagnosticView
            | SolverRadioSelection C.Solver
            | FloatModeRadioSelection T.Text
            | SolverInteractionFileEdit
+           | SelectedBreakpointValue Int
   deriving (Eq, Ord, Show)

--- a/surveyor-brick/src/Surveyor/Brick/Names.hs
+++ b/surveyor-brick/src/Surveyor/Brick/Names.hs
@@ -23,4 +23,7 @@ data Names = DiagnosticView
            | FloatModeRadioSelection T.Text
            | SolverInteractionFileEdit
            | SelectedBreakpointValue Int
+           | ValueViewerList
+           | BreakpointValueSelectorForm
+           | BreakpointValueViewer
   deriving (Eq, Ord, Show)

--- a/surveyor-brick/src/Surveyor/Brick/Widget/SymbolicExecution.hs
+++ b/surveyor-brick/src/Surveyor/Brick/Widget/SymbolicExecution.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE DataKinds #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE ViewPatterns #-}
 module Surveyor.Brick.Widget.SymbolicExecution (
@@ -20,53 +21,66 @@ import qualified Surveyor.Brick.Widget.SymbolicExecution.Inspect as SEI
 import qualified Surveyor.Brick.Widget.SymbolicExecution.StateExplorer as SEE
 import qualified Surveyor.Core as C
 
+-- | This is a wrapper around the core 'C.SymbolicExecutionState' type because
+-- we need to store some additional information with some states, but we can't
+-- really sink it into the core because it is brick-specific.
+--
+-- We could store it in the UI-specific state extension, but it would lead to
+-- more partial code, since the state is only valid when the symbolic execution
+-- is in the corresponding state.
+data SymbolicExecutionManager e arch s where
+  Configuring :: C.SymbolicExecutionState arch s C.Config -> B.Form (C.SymbolicExecutionConfig s) e Names -> SymbolicExecutionManager e arch s
+  Initializing :: C.SymbolicExecutionState arch s C.SetupArgs -> SymbolicExecutionManager e arch s
+  Executing :: C.SymbolicExecutionState arch s C.Execute -> SymbolicExecutionManager e arch s
+  Inspecting :: C.SymbolicExecutionState arch s C.Inspect -> SymbolicExecutionManager e arch s
+  Suspended :: C.SymbolicExecutionState arch s C.Suspend -> SEE.ValueSelectorForm s e -> SymbolicExecutionManager e arch s
 
-data SymbolicExecutionManager e arch s =
-  SymbolicExecutionManager { managerState :: Some (C.SymbolicExecutionState arch s)
-                           , configForm :: B.Form (C.SymbolicExecutionConfig s) e Names
-                           }
+symbolicExecutionManagerState :: SymbolicExecutionManager e arch s -> Some (C.SymbolicExecutionState arch s)
+symbolicExecutionManagerState sem =
+  case sem of
+    Configuring st _ -> Some st
+    Initializing st -> Some st
+    Executing st -> Some st
+    Inspecting st -> Some st
+    Suspended st _ -> Some st
 
 symbolicExecutionManager :: Some (C.SymbolicExecutionState arch s)
                          -> SymbolicExecutionManager e arch s
 symbolicExecutionManager (Some state) =
-  SymbolicExecutionManager { managerState = Some state
-                           , configForm = SEC.form (C.symbolicExecutionConfig state)
-                           }
+  case state of
+    C.Configuring {} -> Configuring state (SEC.form (C.symbolicExecutionConfig state))
+    C.Initializing {} -> Initializing state
+    C.Executing {} -> Executing state
+    C.Inspecting {} -> Inspecting state
+    C.Suspended {} -> Suspended state (SEE.form state)
 
 renderSymbolicExecutionManager :: SymbolicExecutionManager e arch s
                                -> B.Widget Names
-renderSymbolicExecutionManager sem@(managerState -> Some st) =
-  case st of
-    C.Configuring {} -> SEC.renderSymbolicExecutionConfigurator (configForm sem)
-    C.Initializing {} -> SES.renderSymbolicExecutionSetup st
-    C.Executing {} -> SEM.renderSymbolicExecutionMonitor st
-    C.Inspecting {} -> SEI.renderSymbolicExecutionInspector st
-    C.Suspended {} -> SEE.renderSymbolicExecutionStateExplorer st
+renderSymbolicExecutionManager sem =
+  case sem of
+    Configuring _ form -> SEC.renderSymbolicExecutionConfigurator form
+    Initializing st -> SES.renderSymbolicExecutionSetup st
+    Executing st -> SEM.renderSymbolicExecutionMonitor st
+    Inspecting st -> SEI.renderSymbolicExecutionInspector st
+    Suspended st form -> SEE.renderSymbolicExecutionStateExplorer (st, form)
 
 handleSymbolicExecutionManagerEvent :: B.BrickEvent Names e
                                     -> SymbolicExecutionManager e arch s
                                     -> B.EventM Names (SymbolicExecutionManager e arch s)
-handleSymbolicExecutionManagerEvent evt sem@(managerState -> Some st) =
-  case st of
-    C.Configuring {} -> do
-      f' <- SEC.handleSymbolicExecutionConfiguratorEvent evt (configForm sem)
-      return SymbolicExecutionManager { managerState = Some (C.Configuring (B.formState f'))
-                                      , configForm = f'
-                                      }
-    C.Initializing {} -> do
+handleSymbolicExecutionManagerEvent evt sem =
+  case sem of
+    Configuring st f -> do
+      f' <- SEC.handleSymbolicExecutionConfiguratorEvent evt f
+      return (Configuring st f')
+    Initializing st -> do
       st' <- SES.handleSymbolicExecutionSetupEvent evt st
-      return sem { managerState = Some st' }
-    C.Executing {} -> do
+      return (Initializing st')
+    Executing st -> do
       st' <- SEM.handleSymbolicExecutionMonitorEvent evt st
-      return sem { managerState = Some st' }
-    C.Inspecting {} -> do
+      return (Executing st')
+    Inspecting st -> do
       st' <- SEI.handleSymbolicExecutionInspectorEvent evt st
-      return sem { managerState = Some st' }
-    C.Suspended {} -> do
-      st' <- SEE.handleSymbolicExecutionStateExplorerEvent evt st
-      return sem { managerState = Some st' }
-
-
-symbolicExecutionManagerState :: SymbolicExecutionManager e arch s
-                              -> Some (C.SymbolicExecutionState arch s)
-symbolicExecutionManagerState = managerState
+      return (Inspecting st')
+    Suspended st f -> do
+      (st', f') <- SEE.handleSymbolicExecutionStateExplorerEvent evt (st, f)
+      return (Suspended st' f')

--- a/surveyor-brick/src/Surveyor/Brick/Widget/SymbolicExecution.hs
+++ b/surveyor-brick/src/Surveyor/Brick/Widget/SymbolicExecution.hs
@@ -33,7 +33,7 @@ data SymbolicExecutionManager e arch s where
   Initializing :: C.SymbolicExecutionState arch s C.SetupArgs -> SymbolicExecutionManager e arch s
   Executing :: C.SymbolicExecutionState arch s C.Execute -> SymbolicExecutionManager e arch s
   Inspecting :: C.SymbolicExecutionState arch s C.Inspect -> SymbolicExecutionManager e arch s
-  Suspended :: C.SymbolicExecutionState arch s C.Suspend -> SEE.ValueSelectorForm s e -> SymbolicExecutionManager e arch s
+  Suspended :: C.SymbolicExecutionState arch s C.Suspend -> SEE.StateExplorer s e -> SymbolicExecutionManager e arch s
 
 symbolicExecutionManagerState :: SymbolicExecutionManager e arch s -> Some (C.SymbolicExecutionState arch s)
 symbolicExecutionManagerState sem =
@@ -52,7 +52,7 @@ symbolicExecutionManager (Some state) =
     C.Initializing {} -> Initializing state
     C.Executing {} -> Executing state
     C.Inspecting {} -> Inspecting state
-    C.Suspended {} -> Suspended state (SEE.form state)
+    C.Suspended {} -> Suspended state (SEE.stateExplorer state)
 
 renderSymbolicExecutionManager :: SymbolicExecutionManager e arch s
                                -> B.Widget Names

--- a/surveyor-brick/src/Surveyor/Brick/Widget/SymbolicExecution/StateExplorer.hs
+++ b/surveyor-brick/src/Surveyor/Brick/Widget/SymbolicExecution/StateExplorer.hs
@@ -11,13 +11,20 @@ module Surveyor.Brick.Widget.SymbolicExecution.StateExplorer (
 import qualified Brick as B
 import           Control.Lens ( (^.) )
 import           Data.Maybe ( fromMaybe )
+import           Data.Proxy ( Proxy(..) )
 import qualified Data.Text as T
+import qualified Data.Vector as DV
 import qualified Lang.Crucible.CFG.Core as LCCC
 import qualified Lang.Crucible.Simulator.CallFrame as LCSC
 import qualified Lang.Crucible.Simulator.ExecutionTree as CSET
+import qualified Lang.Crucible.Simulator.RegValue as LCSR
+import qualified Lang.Crucible.Types as LCT
+import qualified What4.Expr.Builder as WEB
 
 import           Surveyor.Brick.Names ( Names(..) )
 import qualified Surveyor.Core as C
+
+import qualified Surveyor.Brick.Widget.ValueViewer as WVV
 
 -- | Render a view of the final state from symbolic execution
 --
@@ -38,7 +45,21 @@ renderSymbolicExecutionStateExplorer st =
           B.vBox [ B.txt "Current Function:" B.<+> B.txt (T.pack (show (LCCC.cfgHandle fcfg)))
                  , B.txt "Current Block:" B.<+> B.txt (T.pack (show (cf ^. LCSC.frameBlockID)))
                  , B.txt "Breakpoint name:" B.<+> B.txt (fromMaybe "<Unnamed Breakpoint>" (C.breakpointName =<< mbp))
+                 , maybe B.emptyWidget (renderFirstValue Proxy) (fmap C.breakpointArguments mbp)
                  ]
+
+-- | This is temporary: we need to provide a selector to choose the value to render
+renderFirstValue :: (sym ~ WEB.ExprBuilder s st fs)
+                 => proxy sym
+                 -> DV.Vector (LCSR.RegValue sym LCT.AnyType)
+                 -> B.Widget Names
+renderFirstValue proxy vals
+  | DV.length vals == 0 = B.emptyWidget
+  | otherwise =
+    case vals DV.! 0 of
+      LCSR.AnyValue tp val ->
+        let vv = WVV.valueViewer proxy tp val
+        in WVV.renderValueViewer vv
 
 handleSymbolicExecutionStateExplorerEvent :: B.BrickEvent Names e
                                           -> C.SymbolicExecutionState arch s C.Suspend

--- a/surveyor-brick/src/Surveyor/Brick/Widget/SymbolicExecution/StateExplorer.hs
+++ b/surveyor-brick/src/Surveyor/Brick/Widget/SymbolicExecution/StateExplorer.hs
@@ -10,6 +10,7 @@ module Surveyor.Brick.Widget.SymbolicExecution.StateExplorer (
 
 import qualified Brick as B
 import           Control.Lens ( (^.) )
+import           Data.Maybe ( fromMaybe )
 import qualified Data.Text as T
 import qualified Lang.Crucible.CFG.Core as LCCC
 import qualified Lang.Crucible.Simulator.CallFrame as LCSC
@@ -27,7 +28,7 @@ renderSymbolicExecutionStateExplorer :: forall arch s
                                      -> B.Widget Names
 renderSymbolicExecutionStateExplorer st =
   case st of
-    C.Suspended _surveyorSimState crucSimState ->
+    C.Suspended _surveyorSimState crucSimState mbp ->
       let topFrame = crucSimState ^. CSET.stateTree . CSET.actFrame
       in case topFrame ^. CSET.gpValue of
         LCSC.RF {} -> B.txt "Unexpected Return Frame"
@@ -36,6 +37,7 @@ renderSymbolicExecutionStateExplorer st =
                                    }) ->
           B.vBox [ B.txt "Current Function:" B.<+> B.txt (T.pack (show (LCCC.cfgHandle fcfg)))
                  , B.txt "Current Block:" B.<+> B.txt (T.pack (show (cf ^. LCSC.frameBlockID)))
+                 , B.txt "Breakpoint name:" B.<+> B.txt (fromMaybe "<Unnamed Breakpoint>" (C.breakpointName =<< mbp))
                  ]
 
 handleSymbolicExecutionStateExplorerEvent :: B.BrickEvent Names e

--- a/surveyor-brick/src/Surveyor/Brick/Widget/SymbolicExecution/StateExplorer.hs
+++ b/surveyor-brick/src/Surveyor/Brick/Widget/SymbolicExecution/StateExplorer.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE TypeApplications #-}
 module Surveyor.Brick.Widget.SymbolicExecution.StateExplorer (
   renderSymbolicExecutionStateExplorer,
@@ -9,22 +10,47 @@ module Surveyor.Brick.Widget.SymbolicExecution.StateExplorer (
   ) where
 
 import qualified Brick as B
+import           Brick.Forms ( (@@=) )
+import qualified Brick.Forms as B
 import           Control.Lens ( (^.) )
+import qualified Control.Lens as L
 import           Data.Maybe ( fromMaybe )
+import qualified Data.Parameterized.Context as Ctx
+import           Data.Parameterized.Some ( Some(..) )
 import           Data.Proxy ( Proxy(..) )
 import qualified Data.Text as T
-import qualified Data.Vector as DV
 import qualified Lang.Crucible.CFG.Core as LCCC
 import qualified Lang.Crucible.Simulator.CallFrame as LCSC
-import qualified Lang.Crucible.Simulator.ExecutionTree as CSET
-import qualified Lang.Crucible.Simulator.RegValue as LCSR
-import qualified Lang.Crucible.Types as LCT
+import qualified Lang.Crucible.Simulator.RegMap as LMCR
 import qualified What4.Expr.Builder as WEB
 
 import           Surveyor.Brick.Names ( Names(..) )
 import qualified Surveyor.Core as C
 
 import qualified Surveyor.Brick.Widget.ValueViewer as WVV
+
+-- | This is a simple internal-only type to render our brick form.
+--
+-- The real state type is 'SuspendedState' (unfortunately, it isn't convenient
+-- to use with a brick widget because it contains existentials)
+data ValueSelector sym ctx =
+  ValueSelector { _values :: Ctx.Assignment (LMCR.RegEntry sym) ctx
+                , _index :: Some (Ctx.Index ctx)
+                }
+
+L.makeLenses ''ValueSelector
+
+form :: forall sym ctx e
+      . Ctx.Assignment (LMCR.RegEntry sym) ctx
+     -> ValueSelector sym ctx
+     -> B.Form (ValueSelector sym ctx) e Names
+form vals =
+  B.newForm [ (B.str "Breakpoint Value: " B.<+>) @@= B.radioField index idxList
+            ]
+  where
+    idxEntry :: forall tp . Ctx.Index ctx tp -> (Some (Ctx.Index ctx), Names, T.Text)
+    idxEntry idx = (Some idx, SelectedBreakpointValue (Ctx.indexVal idx), T.pack (show idx))
+    idxList = reverse $ Ctx.forIndex (Ctx.size vals) (\acc idx -> idxEntry idx : acc) []
 
 -- | Render a view of the final state from symbolic execution
 --
@@ -33,35 +59,58 @@ import qualified Surveyor.Brick.Widget.ValueViewer as WVV
 renderSymbolicExecutionStateExplorer :: forall arch s
                                       . C.SymbolicExecutionState arch s C.Suspend
                                      -> B.Widget Names
-renderSymbolicExecutionStateExplorer st =
-  case st of
-    C.Suspended _surveyorSimState crucSimState mbp ->
-      let topFrame = crucSimState ^. CSET.stateTree . CSET.actFrame
-      in case topFrame ^. CSET.gpValue of
-        LCSC.RF {} -> B.txt "Unexpected Return Frame"
-        LCSC.OF {} -> B.txt "Unexpected Override Frame"
-        LCSC.MF cf@(LCSC.CallFrame { LCSC._frameCFG = fcfg
-                                   }) ->
-          B.vBox [ B.txt "Current Function:" B.<+> B.txt (T.pack (show (LCCC.cfgHandle fcfg)))
-                 , B.txt "Current Block:" B.<+> B.txt (T.pack (show (cf ^. LCSC.frameBlockID)))
-                 , B.txt "Breakpoint name:" B.<+> B.txt (fromMaybe "<Unnamed Breakpoint>" (C.breakpointName =<< mbp))
-                 , maybe B.emptyWidget (renderFirstValue Proxy) (fmap C.breakpointArguments mbp)
-                 ]
+renderSymbolicExecutionStateExplorer (C.Suspended suspSt) =
+  case C.suspendedCallFrame suspSt of
+    cf@LCSC.CallFrame { LCSC._frameCFG = fcfg } ->
+      B.vBox [ B.txt "Current Function:" B.<+> B.txt (T.pack (show (LCCC.cfgHandle fcfg)))
+           , B.txt "Current Block:" B.<+> B.txt (T.pack (show (cf ^. LCSC.frameBlockID)))
+           , B.txt "Breakpoint name:" B.<+> B.txt (fromMaybe "<Unnamed Breakpoint>" (C.breakpointName =<< mbp))
+           , renderBreakpointValueSelector regs mIdx
+           , renderSelectedValue Proxy regs mIdx
+           ]
+  where
+    mbp = C.suspendedBreakpoint suspSt
+    regs = C.suspendedRegVals suspSt
+    mIdx = C.suspendedRegSelection suspSt
 
--- | This is temporary: we need to provide a selector to choose the value to render
-renderFirstValue :: (sym ~ WEB.ExprBuilder s st fs)
-                 => proxy sym
-                 -> DV.Vector (LCSR.RegValue sym LCT.AnyType)
-                 -> B.Widget Names
-renderFirstValue proxy vals
-  | DV.length vals == 0 = B.emptyWidget
-  | otherwise =
-    case vals DV.! 0 of
-      LCSR.AnyValue tp val ->
-        let vv = WVV.valueViewer proxy tp val
-        in WVV.renderValueViewer vv
+renderBreakpointValueSelector :: Ctx.Assignment (LMCR.RegEntry sym) ctx
+                              -> Maybe (Some (Ctx.Index ctx))
+                              -> B.Widget Names
+renderBreakpointValueSelector regs mIdx =
+  case mIdx of
+    Nothing -> B.emptyWidget
+    Just idx ->
+      let vs = ValueSelector regs idx
+      in B.renderForm (form regs vs)
+
+renderSelectedValue :: (sym ~ WEB.ExprBuilder s st fs)
+                    => proxy sym
+                    -> Ctx.Assignment (LMCR.RegEntry sym) ctx
+                    -> Maybe (Some (Ctx.Index ctx))
+                    -> B.Widget Names
+renderSelectedValue proxy regs mIdx =
+  case mIdx of
+    Nothing -> B.emptyWidget
+    Just (Some idx) ->
+      case regs Ctx.! idx of
+        LMCR.RegEntry tp val ->
+          let vv = WVV.valueViewer proxy tp val
+          in WVV.renderValueViewer vv
 
 handleSymbolicExecutionStateExplorerEvent :: B.BrickEvent Names e
                                           -> C.SymbolicExecutionState arch s C.Suspend
                                           -> B.EventM Names (C.SymbolicExecutionState arch s C.Suspend)
-handleSymbolicExecutionStateExplorerEvent _evt st = return st
+handleSymbolicExecutionStateExplorerEvent evt s0@(C.Suspended suspSt) =
+  case mIdx of
+    Nothing ->
+      -- If there is no index, that is only because there are no breakpoint
+      -- values (and therefore nothing to select and no events to handle)
+      return s0
+    Just idx -> do
+      let vs = ValueSelector regs idx
+      vs' <- B.formState <$> B.handleFormEvent evt (form regs vs)
+      let suspSt' = suspSt { C.suspendedRegSelection = Just (vs' ^. index) }
+      return (C.Suspended suspSt')
+  where
+    regs = C.suspendedRegVals suspSt
+    mIdx = C.suspendedRegSelection suspSt

--- a/surveyor-brick/src/Surveyor/Brick/Widget/SymbolicExecution/StateExplorer.hs
+++ b/surveyor-brick/src/Surveyor/Brick/Widget/SymbolicExecution/StateExplorer.hs
@@ -7,29 +7,33 @@
 {-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE TypeApplications #-}
 module Surveyor.Brick.Widget.SymbolicExecution.StateExplorer (
-  form,
-  ValueSelectorForm(..),
+  StateExplorer,
+  stateExplorer,
   renderSymbolicExecutionStateExplorer,
   handleSymbolicExecutionStateExplorerEvent
   ) where
 
 import qualified Brick as B
+import qualified Brick.Focus as BF
 import           Brick.Forms ( (@@=) )
 import qualified Brick.Forms as B
 import           Control.Lens ( (^.) )
 import qualified Control.Lens as L
 import           Data.Maybe ( fromMaybe )
+import qualified Data.Parameterized.Classes as PC
 import qualified Data.Parameterized.Context as Ctx
 import           Data.Parameterized.Some ( Some(..) )
 import qualified Data.Parameterized.TraversableFC as FC
 import           Data.Proxy ( Proxy(..) )
 import qualified Data.Text as T
+import qualified Graphics.Vty as GV
 import qualified Lang.Crucible.CFG.Core as LCCC
 import qualified Lang.Crucible.Simulator.CallFrame as LCSC
 import qualified Lang.Crucible.Simulator.RegMap as LMCR
 import qualified What4.Expr.Builder as WEB
 
 import           Surveyor.Brick.Names ( Names(..) )
+import qualified Surveyor.Brick.Panic as SBP
 import qualified Surveyor.Core as C
 
 import qualified Surveyor.Brick.Widget.ValueViewer as WVV
@@ -59,50 +63,70 @@ L.makeLenses ''ValueSelector
 
 -- | This wrapper quantifies out the ctx parameter from the form so that we can
 -- return it
-data ValueSelectorForm s e where
-  NoValues :: ValueSelectorForm s e
-  ValueSelectorForm :: B.Form (ValueSelector s ctx) e Names -> ValueSelectorForm s e
+data ValueSelectorForm s ctx e where
+  NoValues :: ValueSelectorForm s ctx e
+  ValueSelectorForm :: B.Form (ValueSelector s ctx) e Names -> ValueSelectorForm s ctx e
 
-form :: forall e arch s
-      . C.SymbolicExecutionState arch s C.Suspend
-     -> ValueSelectorForm s e
-form (C.Suspended suspSt) =
+data WrappedViewer s (tp :: LCCC.CrucibleType) where
+  WrappedViewer :: WVV.ValueViewer s -> WrappedViewer s tp
+
+-- | Holds the state of the StateExplorer widget
+--
+-- This includes the selected value state as well as the state for the value
+-- viewer widget itself.
+data StateExplorer s e where
+  StateExplorer :: ValueSelectorForm s ctx e
+                -> Ctx.Assignment (WrappedViewer s) ctx
+                -> BF.FocusRing Names
+                -> StateExplorer s e
+
+stateExplorer :: forall e arch s
+               . C.SymbolicExecutionState arch s C.Suspend
+              -> StateExplorer s e
+stateExplorer (C.Suspended suspSt) =
   case C.suspendedRegVals suspSt of
-    Ctx.Empty -> NoValues
+    Ctx.Empty -> StateExplorer NoValues Ctx.Empty (BF.focusRing [])
     vals@(_ Ctx.:> _) ->
       let idxList = reverse $ Ctx.forIndex (Ctx.size vals) (\acc idx -> idxEntry idx : acc) []
-          vs = ValueSelector { _values = FC.fmapFC RegWrapper vals
+          wrappedVals = FC.fmapFC RegWrapper vals
+          vs = ValueSelector { _values = wrappedVals
                              , _index = head idxList ^. L._1
                              }
           formCon = B.newForm [ (B.str "Breakpoint Value: " B.<+>) @@= B.radioField index idxList
                               ]
-      in ValueSelectorForm (formCon vs)
+          vsf = ValueSelectorForm (formCon vs)
+
+          toValueViewer :: forall tp . RegWrapper s tp -> WrappedViewer s tp
+          toValueViewer (RegWrapper (re :: LMCR.RegEntry (WEB.ExprBuilder s st fs) tp)) =
+            case re of
+              LMCR.RegEntry tp rv -> WrappedViewer (WVV.valueViewer (Proxy @(WEB.ExprBuilder s st fs)) tp rv)
+          viewers = FC.fmapFC toValueViewer wrappedVals
+          fr = BF.focusRing [BreakpointValueSelectorForm, BreakpointValueViewer]
+      in StateExplorer vsf viewers fr
   where
-    -- vals = C.suspendedRegVals suspSt
     idxEntry :: forall tp (ctx :: Ctx.Ctx LCCC.CrucibleType) . Ctx.Index ctx tp -> (Some (Ctx.Index ctx), Names, T.Text)
     idxEntry idx = (Some idx, SelectedBreakpointValue (Ctx.indexVal idx), T.pack (show idx))
-
 
 -- | Render a view of the final state from symbolic execution
 --
 -- Eventually, this should provide some mechanisms for deeply inspecting the
 -- state (including arch-specific inspection of memory).
 renderSymbolicExecutionStateExplorer :: forall arch s e
-                                      . (C.SymbolicExecutionState arch s C.Suspend, ValueSelectorForm s e)
+                                      . (C.SymbolicExecutionState arch s C.Suspend, StateExplorer s e)
                                      -> B.Widget Names
-renderSymbolicExecutionStateExplorer (C.Suspended suspSt, vsf) =
+renderSymbolicExecutionStateExplorer (C.Suspended suspSt, se@(StateExplorer vsf _viewers _focus)) =
   case C.suspendedCallFrame suspSt of
     cf@LCSC.CallFrame { LCSC._frameCFG = fcfg } ->
       B.vBox [ B.txt "Current Function:" B.<+> B.txt (T.pack (show (LCCC.cfgHandle fcfg)))
            , B.txt "Current Block:" B.<+> B.txt (T.pack (show (cf ^. LCSC.frameBlockID)))
            , B.txt "Breakpoint name:" B.<+> B.txt (fromMaybe "<Unnamed Breakpoint>" (C.breakpointName =<< mbp))
            , renderBreakpointValueSelector vsf
-           , renderSelectedValue vsf
+           , renderSelectedValue se
            ]
   where
     mbp = C.suspendedBreakpoint suspSt
 
-renderBreakpointValueSelector :: ValueSelectorForm s e
+renderBreakpointValueSelector :: ValueSelectorForm s ctx e
                               -> B.Widget Names
 renderBreakpointValueSelector vsf =
   case vsf of
@@ -110,30 +134,42 @@ renderBreakpointValueSelector vsf =
     ValueSelectorForm f -> B.renderForm f
 
 renderSelectedValue :: forall s e
-                     . ValueSelectorForm s e
+                     . StateExplorer s e
                     -> B.Widget Names
-renderSelectedValue vsf =
+renderSelectedValue (StateExplorer vsf viewers focus) =
   case vsf of
     NoValues -> B.emptyWidget
     ValueSelectorForm f ->
       case f ^. L.to B.formState . index of
         Some idx ->
-          case (f ^. L.to B.formState . values) Ctx.! idx of
-            RegWrapper (re :: LMCR.RegEntry (WEB.ExprBuilder s st fs) tp) ->
-              case re of
-                LMCR.RegEntry tp val ->
-                  let vv = WVV.valueViewer (Proxy @(WEB.ExprBuilder s st fs)) tp val
-                  in WVV.renderValueViewer vv
+          case viewers Ctx.! idx of
+            WrappedViewer vv ->
+              let isFocused = BF.focusGetCurrent focus == Just BreakpointValueViewer
+              in WVV.renderValueViewer isFocused vv
 
 handleSymbolicExecutionStateExplorerEvent :: B.BrickEvent Names e
-                                          -> (C.SymbolicExecutionState arch s C.Suspend, ValueSelectorForm s e)
-                                          -> B.EventM Names (C.SymbolicExecutionState arch s C.Suspend, ValueSelectorForm s e)
-handleSymbolicExecutionStateExplorerEvent evt s0@(C.Suspended suspSt, vsf) =
-  case vsf of
-    NoValues ->
-      -- If there is no index, that is only because there are no breakpoint
-      -- values (and therefore nothing to select and no events to handle)
-      return s0
-    ValueSelectorForm f -> do
-      f' <- B.handleFormEvent evt f
-      return (C.Suspended suspSt, ValueSelectorForm f')
+                                          -> (C.SymbolicExecutionState arch s C.Suspend, StateExplorer s e)
+                                          -> B.EventM Names (C.SymbolicExecutionState arch s C.Suspend, StateExplorer s e)
+handleSymbolicExecutionStateExplorerEvent evt s0@(C.Suspended suspSt, StateExplorer vsf viewers focus) =
+  case evt of
+    B.VtyEvent (GV.EvKey (GV.KChar '\t') []) ->
+      return (C.Suspended suspSt, StateExplorer vsf viewers (BF.focusNext focus))
+    B.VtyEvent ve ->
+      case vsf of
+        NoValues ->
+          -- If there is no index, that is only because there are no breakpoint
+          -- values (and therefore nothing to select and no events to handle)
+          return s0
+        ValueSelectorForm f ->
+          case BF.focusGetCurrent focus of
+            Just BreakpointValueSelectorForm -> do
+              f' <- B.handleFormEvent evt f
+              return (C.Suspended suspSt, StateExplorer (ValueSelectorForm f') viewers focus)
+            Just BreakpointValueViewer -> do
+              case f ^. L.to B.formState . index of
+                Some idx | WrappedViewer valView <- viewers Ctx.! idx -> do
+                  v' <- WVV.handleValueViewerEvent ve valView
+                  let viewers' = L.set (PC.ixF idx) (WrappedViewer v') viewers
+                  return (C.Suspended suspSt, StateExplorer vsf viewers' focus)
+            n -> SBP.panic "handleSymbolicExecutionExplorerEvent" ["Unexpected component in focus ring: " ++ show n]
+    _ -> return s0

--- a/surveyor-brick/src/Surveyor/Brick/Widget/SymbolicExecution/StateExplorer.hs
+++ b/surveyor-brick/src/Surveyor/Brick/Widget/SymbolicExecution/StateExplorer.hs
@@ -1,10 +1,14 @@
+{-# LANGUAGE DataKinds #-}
 {-# LANGUAGE GADTs #-}
+{-# LANGUAGE KindSignatures #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE TypeApplications #-}
 module Surveyor.Brick.Widget.SymbolicExecution.StateExplorer (
+  form,
+  ValueSelectorForm(..),
   renderSymbolicExecutionStateExplorer,
   handleSymbolicExecutionStateExplorerEvent
   ) where
@@ -17,6 +21,7 @@ import qualified Control.Lens as L
 import           Data.Maybe ( fromMaybe )
 import qualified Data.Parameterized.Context as Ctx
 import           Data.Parameterized.Some ( Some(..) )
+import qualified Data.Parameterized.TraversableFC as FC
 import           Data.Proxy ( Proxy(..) )
 import qualified Data.Text as T
 import qualified Lang.Crucible.CFG.Core as LCCC
@@ -29,88 +34,106 @@ import qualified Surveyor.Core as C
 
 import qualified Surveyor.Brick.Widget.ValueViewer as WVV
 
--- | This is a simple internal-only type to render our brick form.
+-- | This is a wrapper around a symbolic-execution time value (a RegEntry).  The
+-- wrapper is helpful for hiding the @sym@ type parameter while still leaving
+-- 'ValueSelector' as a plain data type (so lenses and brick still work).
 --
--- The real state type is 'SuspendedState' (unfortunately, it isn't convenient
--- to use with a brick widget because it contains existentials)
-data ValueSelector sym ctx =
-  ValueSelector { _values :: Ctx.Assignment (LMCR.RegEntry sym) ctx
+-- While we hide the parameter, we do record the concrete symbolic backend type
+-- so that we can traverse terms.
+--
+-- While this quantification is useful for now, it could become problematic if
+-- we need to use any of this information with values taken from the symbolic
+-- execution state, which has separately quantified it all out.
+data RegWrapper s tp where
+  RegWrapper :: LMCR.RegEntry (WEB.ExprBuilder s st fs) tp -> RegWrapper s tp
+
+-- | This is a type capturing the data necessary to render the value selector form
+--
+-- We have to carefully quantify type parameters so that we can mesh well with brick.
+data ValueSelector s ctx =
+  ValueSelector { _values :: Ctx.Assignment (RegWrapper s) ctx
                 , _index :: Some (Ctx.Index ctx)
                 }
 
 L.makeLenses ''ValueSelector
 
-form :: forall sym ctx e
-      . Ctx.Assignment (LMCR.RegEntry sym) ctx
-     -> ValueSelector sym ctx
-     -> B.Form (ValueSelector sym ctx) e Names
-form vals =
-  B.newForm [ (B.str "Breakpoint Value: " B.<+>) @@= B.radioField index idxList
-            ]
+-- | This wrapper quantifies out the ctx parameter from the form so that we can
+-- return it
+data ValueSelectorForm s e where
+  NoValues :: ValueSelectorForm s e
+  ValueSelectorForm :: B.Form (ValueSelector s ctx) e Names -> ValueSelectorForm s e
+
+form :: forall e arch s
+      . C.SymbolicExecutionState arch s C.Suspend
+     -> ValueSelectorForm s e
+form (C.Suspended suspSt) =
+  case C.suspendedRegVals suspSt of
+    Ctx.Empty -> NoValues
+    vals@(_ Ctx.:> _) ->
+      let idxList = reverse $ Ctx.forIndex (Ctx.size vals) (\acc idx -> idxEntry idx : acc) []
+          vs = ValueSelector { _values = FC.fmapFC RegWrapper vals
+                             , _index = head idxList ^. L._1
+                             }
+          formCon = B.newForm [ (B.str "Breakpoint Value: " B.<+>) @@= B.radioField index idxList
+                              ]
+      in ValueSelectorForm (formCon vs)
   where
-    idxEntry :: forall tp . Ctx.Index ctx tp -> (Some (Ctx.Index ctx), Names, T.Text)
+    -- vals = C.suspendedRegVals suspSt
+    idxEntry :: forall tp (ctx :: Ctx.Ctx LCCC.CrucibleType) . Ctx.Index ctx tp -> (Some (Ctx.Index ctx), Names, T.Text)
     idxEntry idx = (Some idx, SelectedBreakpointValue (Ctx.indexVal idx), T.pack (show idx))
-    idxList = reverse $ Ctx.forIndex (Ctx.size vals) (\acc idx -> idxEntry idx : acc) []
+
 
 -- | Render a view of the final state from symbolic execution
 --
 -- Eventually, this should provide some mechanisms for deeply inspecting the
 -- state (including arch-specific inspection of memory).
-renderSymbolicExecutionStateExplorer :: forall arch s
-                                      . C.SymbolicExecutionState arch s C.Suspend
+renderSymbolicExecutionStateExplorer :: forall arch s e
+                                      . (C.SymbolicExecutionState arch s C.Suspend, ValueSelectorForm s e)
                                      -> B.Widget Names
-renderSymbolicExecutionStateExplorer (C.Suspended suspSt) =
+renderSymbolicExecutionStateExplorer (C.Suspended suspSt, vsf) =
   case C.suspendedCallFrame suspSt of
     cf@LCSC.CallFrame { LCSC._frameCFG = fcfg } ->
       B.vBox [ B.txt "Current Function:" B.<+> B.txt (T.pack (show (LCCC.cfgHandle fcfg)))
            , B.txt "Current Block:" B.<+> B.txt (T.pack (show (cf ^. LCSC.frameBlockID)))
            , B.txt "Breakpoint name:" B.<+> B.txt (fromMaybe "<Unnamed Breakpoint>" (C.breakpointName =<< mbp))
-           , renderBreakpointValueSelector regs mIdx
-           , renderSelectedValue Proxy regs mIdx
+           , renderBreakpointValueSelector vsf
+           , renderSelectedValue vsf
            ]
   where
     mbp = C.suspendedBreakpoint suspSt
-    regs = C.suspendedRegVals suspSt
-    mIdx = C.suspendedRegSelection suspSt
 
-renderBreakpointValueSelector :: Ctx.Assignment (LMCR.RegEntry sym) ctx
-                              -> Maybe (Some (Ctx.Index ctx))
+renderBreakpointValueSelector :: ValueSelectorForm s e
                               -> B.Widget Names
-renderBreakpointValueSelector regs mIdx =
-  case mIdx of
-    Nothing -> B.emptyWidget
-    Just idx ->
-      let vs = ValueSelector regs idx
-      in B.renderForm (form regs vs)
+renderBreakpointValueSelector vsf =
+  case vsf of
+    NoValues -> B.emptyWidget
+    ValueSelectorForm f -> B.renderForm f
 
-renderSelectedValue :: (sym ~ WEB.ExprBuilder s st fs)
-                    => proxy sym
-                    -> Ctx.Assignment (LMCR.RegEntry sym) ctx
-                    -> Maybe (Some (Ctx.Index ctx))
+renderSelectedValue :: forall s e
+                     . ValueSelectorForm s e
                     -> B.Widget Names
-renderSelectedValue proxy regs mIdx =
-  case mIdx of
-    Nothing -> B.emptyWidget
-    Just (Some idx) ->
-      case regs Ctx.! idx of
-        LMCR.RegEntry tp val ->
-          let vv = WVV.valueViewer proxy tp val
-          in WVV.renderValueViewer vv
+renderSelectedValue vsf =
+  case vsf of
+    NoValues -> B.emptyWidget
+    ValueSelectorForm f ->
+      case f ^. L.to B.formState . index of
+        Some idx ->
+          case (f ^. L.to B.formState . values) Ctx.! idx of
+            RegWrapper (re :: LMCR.RegEntry (WEB.ExprBuilder s st fs) tp) ->
+              case re of
+                LMCR.RegEntry tp val ->
+                  let vv = WVV.valueViewer (Proxy @(WEB.ExprBuilder s st fs)) tp val
+                  in WVV.renderValueViewer vv
 
 handleSymbolicExecutionStateExplorerEvent :: B.BrickEvent Names e
-                                          -> C.SymbolicExecutionState arch s C.Suspend
-                                          -> B.EventM Names (C.SymbolicExecutionState arch s C.Suspend)
-handleSymbolicExecutionStateExplorerEvent evt s0@(C.Suspended suspSt) =
-  case mIdx of
-    Nothing ->
+                                          -> (C.SymbolicExecutionState arch s C.Suspend, ValueSelectorForm s e)
+                                          -> B.EventM Names (C.SymbolicExecutionState arch s C.Suspend, ValueSelectorForm s e)
+handleSymbolicExecutionStateExplorerEvent evt s0@(C.Suspended suspSt, vsf) =
+  case vsf of
+    NoValues ->
       -- If there is no index, that is only because there are no breakpoint
       -- values (and therefore nothing to select and no events to handle)
       return s0
-    Just idx -> do
-      let vs = ValueSelector regs idx
-      vs' <- B.formState <$> B.handleFormEvent evt (form regs vs)
-      let suspSt' = suspSt { C.suspendedRegSelection = Just (vs' ^. index) }
-      return (C.Suspended suspSt')
-  where
-    regs = C.suspendedRegVals suspSt
-    mIdx = C.suspendedRegSelection suspSt
+    ValueSelectorForm f -> do
+      f' <- B.handleFormEvent evt f
+      return (C.Suspended suspSt, ValueSelectorForm f')

--- a/surveyor-brick/src/Surveyor/Brick/Widget/ValueViewer.hs
+++ b/surveyor-brick/src/Surveyor/Brick/Widget/ValueViewer.hs
@@ -31,6 +31,7 @@ import qualified What4.Expr.WeightedSum as WSum
 import qualified What4.Interface as WI
 import qualified What4.SemiRing as SR
 import qualified What4.Symbol as WS
+import qualified What4.Utils.StringLiteral as WUS
 
 import           Surveyor.Brick.Names ( Names(..) )
 
@@ -128,6 +129,11 @@ buildTermWidget tp re =
       case re of
         WEB.BoolExpr b _ -> return (RenderInline (B.txt (T.pack (show b))))
         WEB.SemiRingLiteral srep coeff _loc -> RenderInline <$> renderCoefficient srep coeff
+        WEB.StringExpr sl _loc ->
+          case sl of
+            WUS.UnicodeLiteral t -> return (RenderInline (B.txt "\"" B.<+> B.txt t B.<+> B.txt "\""))
+            WUS.Char8Literal bs -> return (RenderInline (B.str (show bs)))
+            WUS.Char16Literal ws -> return (RenderInline (B.str (show ws)))
         WEB.BoundVarExpr bv ->
           return (RenderInline (B.txt "$" B.<+> B.txt (WS.solverSymbolAsText (WEB.bvarName bv))))
         WEB.AppExpr ae -> do

--- a/surveyor-brick/src/Surveyor/Brick/Widget/ValueViewer.hs
+++ b/surveyor-brick/src/Surveyor/Brick/Widget/ValueViewer.hs
@@ -1,4 +1,12 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GADTs #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE KindSignatures #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
 -- | A viewer for Crucible run-time values (RegEntries)
 module Surveyor.Brick.Widget.ValueViewer (
   ValueViewer,
@@ -7,25 +15,162 @@ module Surveyor.Brick.Widget.ValueViewer (
   ) where
 
 import qualified Brick as B
-import qualified Data.Functor.Const as C
+import qualified Control.Monad.State.Strict as St
 import qualified Data.Parameterized.Map as MapF
 import qualified Data.Parameterized.Nonce as PN
-import qualified Lang.Crucible.Simulator.RegMap as CSR
+import           Data.Proxy ( Proxy(..) )
+import qualified Data.Text as T
+import qualified Lang.Crucible.Simulator.RegValue as LCSR
+import qualified Lang.Crucible.Types as LCT
+import qualified What4.BaseTypes as WT
+import qualified What4.Expr.Builder as WEB
 
 import           Surveyor.Brick.Names ( Names(..) )
 
 data ValueViewerState s sym tp =
-  ValueViewerState { regEntry :: CSR.RegEntry sym tp
-                   , cache :: MapF.MapF (PN.Nonce s) (C.Const (B.Widget Names))
+  ValueViewerState { regType :: LCT.TypeRepr tp
+                   , regValue :: LCSR.RegValue sym tp
+                   , cache :: MapF.MapF (PN.Nonce s) ConstWidget
                    -- ^ Previous translations of terms into widgets, cached to
                    -- avoid recomputation
+                   , vsProxy :: Proxy sym
                    }
 
 data ValueViewer s where
   ValueViewer :: ValueViewerState s sym tp -> ValueViewer s
 
-valueViewer :: CSR.RegEntry sym tp -> ValueViewer s
-valueViewer re = ValueViewer (ValueViewerState re MapF.empty)
+valueViewer :: forall proxy sym tp s st fs
+             . (sym ~ WEB.ExprBuilder s st fs)
+            => proxy sym
+            -> LCT.TypeRepr tp
+            -> LCSR.RegValue sym tp
+            -> ValueViewer s
+valueViewer p tp re =
+  St.evalState (unViewBuilder (buildViewer p tp re)) MapF.empty
+
+-- | Mark widgets as either being rendered inline in operand positions or as
+-- generating a binding that will be referred to by a number in an operand
+-- position
+data RenderWidget = RenderInline (B.Widget Names)
+                  | RenderBound (B.Widget Names) (B.Widget Names)
+
+newtype ConstWidget (tp :: WT.BaseType) = ConstWidget RenderWidget
+
+newtype ViewerBuilder s sym a =
+  ViewerBuilder { unViewBuilder :: St.State (MapF.MapF (PN.Nonce s) ConstWidget) a
+                }
+  deriving ( Functor
+           , Monad
+           , Applicative
+           , St.MonadState (MapF.MapF (PN.Nonce s) ConstWidget)
+           )
+
+buildViewer :: forall proxy sym tp s st fs
+             . (sym ~ WEB.ExprBuilder s st fs)
+            => proxy sym
+            -> LCT.TypeRepr tp
+            -> LCSR.RegValue sym tp
+            -> ViewerBuilder s sym (ValueViewer s)
+buildViewer _p tp re = do
+  -- Traverse the whole term initially to cache any widgets we can based on nonces.
+  --
+  -- We'll use this same primitive for rendering later, but then we'll start it
+  -- with a primed cache
+  _ <- buildTermWidget tp re
+  c <- St.get
+  return (ValueViewer (ValueViewerState tp re c (Proxy @sym)))
+
+buildTermWidget :: (sym ~ WEB.ExprBuilder s st fs)
+                => LCT.TypeRepr tp
+                -> LCSR.RegValue sym tp
+                -> ViewerBuilder s sym RenderWidget
+buildTermWidget tp re =
+  case LCT.asBaseType tp of
+    LCT.NotBaseType ->
+      case tp of
+        LCT.UnitRepr ->
+          -- We don't update the cache here because we don't have a nonce for these
+          return (RenderInline (B.txt "()"))
+    LCT.AsBaseType _btp ->
+      case re of
+        WEB.BoolExpr b _ -> return (RenderInline (B.txt (T.pack (show b))))
+        WEB.AppExpr ae -> do
+          let nonce = WEB.appExprId ae
+          m <- St.get
+          case MapF.lookup nonce m of
+            Just (ConstWidget cached) -> return cached
+            Nothing ->
+              case WEB.appExprApp ae of
+                WEB.NotPred e -> bindUnaryExpr ae LCT.BoolRepr e "notPred"
+
+                WEB.RealIsInteger e -> bindUnaryExpr ae LCT.RealValRepr e "realIsInteger"
+
+                WEB.NatDiv e1 e2 -> bindBinExpr ae LCT.NatRepr e1 e2 "natDiv"
+                WEB.NatMod e1 e2 -> bindBinExpr ae LCT.NatRepr e1 e2 "natMod"
+
+                WEB.IntDiv e1 e2 -> bindBinExpr ae LCT.IntegerRepr e1 e2 "intDiv"
+                WEB.IntMod e1 e2 -> bindBinExpr ae LCT.IntegerRepr e1 e2 "intMod"
+
+                WEB.RealDiv e1 e2 -> bindBinExpr ae LCT.RealValRepr e1 e2 "realDiv"
+                WEB.RealSqrt e -> bindUnaryExpr ae LCT.RealValRepr e "realSqrt"
+
+                WEB.RealSin e -> bindUnaryExpr ae LCT.RealValRepr e "realSin"
+                WEB.RealCos e -> bindUnaryExpr ae LCT.RealValRepr e "realCos"
+                WEB.RealATan2 e1 e2 -> bindBinExpr ae LCT.RealValRepr e1 e2 "realATan2"
+                WEB.RealSinh e -> bindUnaryExpr ae LCT.RealValRepr e "realSinh"
+                WEB.RealCosh e -> bindUnaryExpr ae LCT.RealValRepr e "realCosh"
+                WEB.RealExp e -> bindUnaryExpr ae LCT.RealValRepr e "realExp"
+                WEB.RealLog e -> bindUnaryExpr ae LCT.RealValRepr e "realLog"
+
+
+bindBinExpr :: (sym ~ WEB.ExprBuilder s st fs)
+            => WEB.AppExpr s tp1
+            -> LCT.TypeRepr tp2
+            -> LCSR.RegValue sym tp2
+            -> LCSR.RegValue sym tp2
+            -> T.Text
+            -> ViewerBuilder s sym RenderWidget
+bindBinExpr ae repr e1 e2 name = do
+  e1' <- argRef <$> buildTermWidget repr e1
+  e2' <- argRef <$> buildTermWidget repr e2
+  bindExpr ae (B.txt name B.<+> e1' B.<+> e2')
+
+bindUnaryExpr :: (sym ~ WEB.ExprBuilder s st fs)
+              => WEB.AppExpr s tp1
+              -> LCT.TypeRepr tp2
+              -> LCSR.RegValue sym tp2
+              -> T.Text
+              -> ViewerBuilder s sym RenderWidget
+bindUnaryExpr ae repr e name = do
+  e' <- argRef <$> buildTermWidget repr e
+  bindExpr ae (B.txt name B.<+> e')
+
+bindExpr :: WEB.AppExpr t tp -> B.Widget Names -> ViewerBuilder t sym RenderWidget
+bindExpr ae w = returnCached (WEB.appExprId ae) $! RenderBound (thisRef ae) w
+
+returnCached :: forall s sym (tp :: WT.BaseType)
+              . PN.Nonce s tp
+             -> RenderWidget
+             -> ViewerBuilder s sym RenderWidget
+returnCached nonce res = do
+  St.modify' $ MapF.insert nonce (ConstWidget res)
+  return res
+
+thisRef :: WEB.AppExpr t tp -> B.Widget n
+thisRef ae = B.txt (T.pack (show (WEB.appExprId ae)))
+
+-- | Extract a widget that should be used to refer to the given 'RenderWidget'
+-- as an operand
+--
+-- For values that should be rendered inline, it is the value itself
+--
+-- For compound values that must be bound, this widget is the unique identifier
+-- bound to the term
+argRef :: RenderWidget -> B.Widget Names
+argRef widget =
+  case widget of
+    RenderInline w -> w
+    RenderBound r _ -> r
 
 renderValueViewer :: ValueViewer s -> B.Widget Names
 renderValueViewer vv = B.vBox []

--- a/surveyor-brick/src/Surveyor/Brick/Widget/ValueViewer.hs
+++ b/surveyor-brick/src/Surveyor/Brick/Widget/ValueViewer.hs
@@ -153,11 +153,11 @@ buildTermWidget tp re =
                         SR.SemiRingNatRepr -> ("natSum", "natMul")
                         SR.SemiRingBVRepr SR.BVArithRepr _w -> ("bvSum", "bvMul")
                         SR.SemiRingBVRepr SR.BVBitsRepr _w -> ("bvXor", "bvAnd")
-                  let renderAdd e1 e2 = return $ intersperse [B.txt addOp, e1, e2]
+                  let renderAdd e1 e2 = return (B.txt "(" B.<+> intersperse [B.txt addOp, e1, e2] B.<+> B.txt ")")
                   let scalarMult coef val = do
                         val' <- argRef <$> buildTermWidget (LCT.baseToType (WI.exprType val)) val
                         coefw <- renderCoefficient (WSum.sumRepr ws) coef
-                        return (intersperse [B.txt mulOp, coefw, val'])
+                        return (B.txt "(" B.<+> intersperse [B.txt mulOp, coefw, val'] B.<+> B.txt ")")
                   let constEval = renderCoefficient (WSum.sumRepr ws)
                   sumTerm <- WSum.evalM renderAdd scalarMult constEval ws
                   bindExpr ae sumTerm

--- a/surveyor-brick/src/Surveyor/Brick/Widget/ValueViewer.hs
+++ b/surveyor-brick/src/Surveyor/Brick/Widget/ValueViewer.hs
@@ -318,7 +318,8 @@ renderCoefficient srep coeff =
     SR.SemiRingNatRepr -> return (B.str (show coeff))
     SR.SemiRingIntegerRepr -> return (B.str (show coeff))
     SR.SemiRingRealRepr -> return (B.str (show coeff))
-    SR.SemiRingBVRepr bvFlv nr ->
+    -- FIXME? We could use the width repr to influence the printing to pad values all the way out
+    SR.SemiRingBVRepr bvFlv _nr ->
       case bvFlv of
         SR.BVArithRepr -> return (B.str (show coeff))
         SR.BVBitsRepr -> return (B.str (printf "0x%x" coeff))

--- a/surveyor-brick/src/Surveyor/Brick/Widget/ValueViewer.hs
+++ b/surveyor-brick/src/Surveyor/Brick/Widget/ValueViewer.hs
@@ -214,6 +214,9 @@ buildTermWidget tp re =
                 WEB.BVRor _rep e1 e2 -> bindBinExpr ae e1 e2 "bvRor"
                 WEB.BVZext _rep e -> bindUnaryExpr ae e "bvZext"
                 WEB.BVSext _rep e -> bindUnaryExpr ae e "bvSext"
+                WEB.BVPopcount _rep e -> bindUnaryExpr ae e "bvPopcount"
+                WEB.BVCountTrailingZeros _rep e -> bindUnaryExpr ae e "bvCtz"
+                WEB.BVCountLeadingZeros _rep e -> bindUnaryExpr ae e "bvClz"
 
                 _ -> return (RenderInline (B.txt "Unhandled app"))
 

--- a/surveyor-brick/src/Surveyor/Brick/Widget/ValueViewer.hs
+++ b/surveyor-brick/src/Surveyor/Brick/Widget/ValueViewer.hs
@@ -139,6 +139,7 @@ buildTermWidget tp re =
                 WEB.NotPred e -> bindUnaryExpr ae e "notPred"
 
                 WEB.SemiRingSum ws -> do
+                  -- FIXME: need to check the repr to determine the operators
                   let renderAdd e1 e2 = return $ intersperse [e1, B.txt "+", e2]
                   let scalarMult coef val = do
                         val' <- argRef <$> buildTermWidget (LCT.baseToType (WI.exprType val)) val
@@ -147,6 +148,15 @@ buildTermWidget tp re =
                   let constEval = renderCoefficient (WSum.sumRepr ws)
                   sumTerm <- WSum.evalM renderAdd scalarMult constEval ws
                   bindExpr ae sumTerm
+
+                WEB.SemiRingProd rp -> do
+                  -- FIXME: Need to check the repr to determine the operators
+                  let mul e1 e2 = return $ intersperse [e1, B.txt "*", e2]
+                  let tm val = argRef <$> buildTermWidget (LCT.baseToType (WI.exprType val)) val
+                  mProdTerm <- WSum.prodEvalM mul tm rp
+                  case mProdTerm of
+                    Nothing -> error "Unit for this repr"
+                    Just t -> bindExpr ae t
 
                 WEB.RealIsInteger e -> bindUnaryExpr ae e "realIsInteger"
 

--- a/surveyor-brick/src/Surveyor/Brick/Widget/ValueViewer.hs
+++ b/surveyor-brick/src/Surveyor/Brick/Widget/ValueViewer.hs
@@ -1,0 +1,31 @@
+{-# LANGUAGE GADTs #-}
+-- | A viewer for Crucible run-time values (RegEntries)
+module Surveyor.Brick.Widget.ValueViewer (
+  ValueViewer,
+  valueViewer,
+  renderValueViewer
+  ) where
+
+import qualified Brick as B
+import qualified Data.Functor.Const as C
+import qualified Data.Parameterized.Map as MapF
+import qualified Data.Parameterized.Nonce as PN
+import qualified Lang.Crucible.Simulator.RegMap as CSR
+
+import           Surveyor.Brick.Names ( Names(..) )
+
+data ValueViewerState s sym tp =
+  ValueViewerState { regEntry :: CSR.RegEntry sym tp
+                   , cache :: MapF.MapF (PN.Nonce s) (C.Const (B.Widget Names))
+                   -- ^ Previous translations of terms into widgets, cached to
+                   -- avoid recomputation
+                   }
+
+data ValueViewer s where
+  ValueViewer :: ValueViewerState s sym tp -> ValueViewer s
+
+valueViewer :: CSR.RegEntry sym tp -> ValueViewer s
+valueViewer re = ValueViewer (ValueViewerState re MapF.empty)
+
+renderValueViewer :: ValueViewer s -> B.Widget Names
+renderValueViewer vv = B.vBox []

--- a/surveyor-brick/surveyor-brick.cabal
+++ b/surveyor-brick/surveyor-brick.cabal
@@ -46,6 +46,7 @@ library
                        deepseq,
                        containers,
                        async,
+                       mtl,
                        bytestring,
                        text,
                        vector,

--- a/surveyor-brick/surveyor-brick.cabal
+++ b/surveyor-brick/surveyor-brick.cabal
@@ -30,6 +30,7 @@ library
                        Surveyor.Brick.Widget.SymbolicExecution.Monitor
                        Surveyor.Brick.Widget.SymbolicExecution.Setup
                        Surveyor.Brick.Widget.SymbolicExecution.StateExplorer
+                       Surveyor.Brick.Widget.ValueViewer
                        Brick.Match.Subword
                        Brick.Widget.FilterList
                        Brick.Widget.Graph

--- a/surveyor-brick/surveyor-brick.cabal
+++ b/surveyor-brick/surveyor-brick.cabal
@@ -68,6 +68,7 @@ library
                        haggle,
                        what4,
                        crucible,
+                       crucible-llvm,
                        surveyor-core
   hs-source-dirs:      src
   default-language:    Haskell2010

--- a/surveyor-core/src/Surveyor/Core.hs
+++ b/surveyor-core/src/Surveyor/Core.hs
@@ -123,6 +123,10 @@ module Surveyor.Core (
   SymEx.configSolverL,
   SymEx.configFloatReprL,
   SymEx.solverInteractionFileL,
+  -- ** Breakpoints
+  SB.Breakpoint(..),
+  SB.BreakpointType(..),
+  SB.classifyBreakpoint,
   -- ** Modifiers
   CCX.resetBlockSelection,
   CCX.selectNextInstruction,
@@ -192,6 +196,7 @@ module Surveyor.Core (
 import qualified Surveyor.Core.Architecture as CA
 import qualified Surveyor.Core.Arguments as AR
 import qualified Surveyor.Core.Async as CAS
+import qualified Surveyor.Core.Breakpoint as SB
 import qualified Surveyor.Core.Chan as CS
 import qualified Surveyor.Core.Command as CC
 import           Surveyor.Core.Commands

--- a/surveyor-core/src/Surveyor/Core.hs
+++ b/surveyor-core/src/Surveyor/Core.hs
@@ -108,6 +108,8 @@ module Surveyor.Core (
   SymEx.singleSessionState,
   SymEx.updateSessionMetrics,
   SymEx.SymbolicExecutionState(..),
+  SymEx.SuspendedState(..),
+  SymEx.suspendedState,
   SymEx.Config,
   SymEx.SetupArgs,
   SymEx.Execute,

--- a/surveyor-core/src/Surveyor/Core/Breakpoint.hs
+++ b/surveyor-core/src/Surveyor/Core/Breakpoint.hs
@@ -1,0 +1,68 @@
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE OverloadedStrings #-}
+module Surveyor.Core.Breakpoint (
+  Breakpoint(..),
+  BreakpointType(..),
+  classifyBreakpoint
+  ) where
+
+import           Control.Lens ( (^.) )
+import qualified Data.Parameterized.Context as Ctx
+import qualified Data.Text as T
+import qualified Data.Vector as DV
+
+import qualified Lang.Crucible.Simulator.CallFrame as LCSC
+import qualified Lang.Crucible.Simulator.ExecutionTree as LCSET
+import qualified Lang.Crucible.Simulator.RegMap as CSR
+import qualified Lang.Crucible.Simulator.RegValue as LCSR
+import qualified Lang.Crucible.Types as LCT
+
+data BreakpointType sym = UnconditionalBreakpoint
+                        | ConditionalBreakpoint (LCSR.RegValue sym LCT.BoolType)
+
+data Breakpoint sym =
+  Breakpoint { breakpointType :: BreakpointType sym
+             , breakpointName :: Maybe T.Text
+             , breakpointArguments :: DV.Vector (LCSR.RegValue sym LCT.AnyType)
+             }
+
+-- | Classify a call as a known breakpoint (or not)
+--
+-- All of our breakpoints are overrides with distinguished name
+--
+-- The first argument of the (unconditional) breakpoint function is the name.
+-- The rest of the arguments are values that can be viewed easily from the
+-- debugger.
+--
+-- FIXME: Interpreting the string here is a bit tricky.  In the LLVM frontend,
+-- it is represented as an LLVMPointer intrinsic type.  We can't mention that
+-- type here because the architecture and extension types are polymorphic.
+-- We'll need a typeclass method (probably based on arch) that lets us dig into
+-- arch-specific types.  Additionally, that function will need access to the
+-- full SimState, as loading a string from memory in LLVM requires reading from
+-- memory.
+classifyBreakpoint :: LCSET.ResolvedCall p sym ext ret -> Maybe (Breakpoint sym)
+classifyBreakpoint rc =
+  case rc of
+    LCSET.CrucibleCall {} -> Nothing
+    LCSET.OverrideCall o fr
+      | LCSET.overrideName o == "crucible_breakpoint" ->
+        case CSR.regMap (fr ^. LCSC.overrideRegMap) of
+          Ctx.Empty Ctx.:> name Ctx.:> args
+            | LCT.VectorRepr LCT.AnyRepr <- CSR.regType args ->
+              Just $ Breakpoint { breakpointType = UnconditionalBreakpoint
+                                , breakpointName = Nothing
+                                , breakpointArguments = CSR.regValue args
+                                }
+          _ -> Nothing
+      | LCSET.overrideName o == "crucible_breakpoint_if" ->
+        case CSR.regMap (fr ^. LCSC.overrideRegMap) of
+          Ctx.Empty Ctx.:> name Ctx.:> predicate Ctx.:> args
+            | LCT.VectorRepr LCT.AnyRepr <- CSR.regType args
+            , LCT.BoolRepr <- CSR.regType predicate ->
+              Just $ Breakpoint { breakpointType = ConditionalBreakpoint (CSR.regValue predicate)
+                                , breakpointName = Nothing
+                                , breakpointArguments = CSR.regValue args
+                                }
+          _ -> Nothing
+      | otherwise -> Nothing

--- a/surveyor-core/src/Surveyor/Core/SymbolicExecution.hs
+++ b/surveyor-core/src/Surveyor/Core/SymbolicExecution.hs
@@ -36,6 +36,8 @@ module Surveyor.Core.SymbolicExecution (
   Inspect,
   Suspend,
   SymbolicExecutionState(..),
+  SuspendedState(..),
+  suspendedState,
   symbolicExecutionConfig,
   initialSymbolicExecutionState,
   startSymbolicExecution,
@@ -51,25 +53,34 @@ module Surveyor.Core.SymbolicExecution (
   ) where
 
 import           Control.DeepSeq ( NFData(..), deepseq )
+import           Control.Lens ( (^.) )
 import qualified Control.Lens as L
 import           Control.Monad ( unless )
+import qualified Control.Monad.Catch as CMC
 import qualified Data.Functor.Identity as I
 import qualified Data.IORef as IOR
 import qualified Data.Map.Strict as Map
+import           Data.Maybe ( fromMaybe )
+import qualified Data.Parameterized.Context as Ctx
 import qualified Data.Parameterized.Nonce as PN
 import           Data.Parameterized.Some ( Some(..) )
 import qualified Data.Parameterized.TraversableFC as FC
 import           Data.Proxy ( Proxy(..) )
 import qualified Data.Text as T
+import qualified Data.Vector as DV
 import qualified Lang.Crucible.Backend as CB
 import qualified Lang.Crucible.Backend.Online as CBO
 import qualified Lang.Crucible.CFG.Core as CCC
 import qualified Lang.Crucible.CFG.Extension as CCE
 import qualified Lang.Crucible.Simulator as CS
+import qualified Lang.Crucible.Simulator.CallFrame as LCSC
 import qualified Lang.Crucible.Simulator.EvalStmt as CSE
 import qualified Lang.Crucible.Simulator.ExecutionTree as CSET
 import qualified Lang.Crucible.Simulator.Profiling as CSP
+import qualified Lang.Crucible.Simulator.RegMap as LMCR
+import qualified Lang.Crucible.Simulator.RegValue as LCSR
 import qualified Lang.Crucible.Types as CT
+import qualified Lang.Crucible.Types as LCT
 import qualified System.IO as IO
 import qualified System.Process as SP
 import qualified What4.Concrete as WCC
@@ -135,10 +146,78 @@ data SymbolicExecutionState arch s (k :: SymExK) where
                , ext ~ CA.CrucibleExt arch
                , sym ~ WEB.ExprBuilder s st fs
                )
-            => SymbolicState arch s sym init reg
-            -> CSET.SimState p sym ext rtp f a
-            -> Maybe (SCB.Breakpoint sym)
+            => SuspendedState sym init reg p ext args blocks ret rtp f a ctx arch s
             -> SymbolicExecutionState arch s Suspend
+
+data SuspendedState sym init reg p ext args blocks ret rtp f a ctx arch s =
+  SuspendedState { suspendedSymState :: SymbolicState arch s sym init reg
+                 , suspendedSimState :: CSET.SimState p sym ext rtp f a
+                 , suspendedCallFrame :: LCSC.CallFrame sym ext blocks ret args
+                 , suspendedBreakpoint :: Maybe (SCB.Breakpoint sym)
+                 , suspendedRegVals :: Ctx.Assignment (LMCR.RegEntry sym) ctx
+                 , suspendedRegSelection :: Maybe (Some (Ctx.Index ctx))
+                 }
+
+data SymbolicExecutionException =
+  UnexpectedFrame T.Text T.Text
+  deriving (Show)
+
+instance CMC.Exception SymbolicExecutionException
+
+suspendedState :: forall sym arch s ext st fs m init reg p rtp f a
+                . ( CB.IsSymInterface sym
+                  , CA.Architecture arch s
+                  , ext ~ CA.CrucibleExt arch
+                  , sym ~ WEB.ExprBuilder s st fs
+                  , CMC.MonadThrow m
+                  )
+               => SymbolicState arch s sym init reg
+               -> CSET.SimState p sym ext rtp f a
+               -> Maybe (SCB.Breakpoint sym)
+               -> m (SymbolicExecutionState arch s Suspend)
+suspendedState surveyorSymState crucSimState mbp =
+  case topFrame ^. CSET.gpValue of
+    LCSC.RF {} -> CMC.throwM (UnexpectedFrame "Return" bpName)
+    LCSC.OF {} -> CMC.throwM (UnexpectedFrame "Override" bpName)
+    LCSC.MF cf ->
+      case maybe (Some Ctx.Empty) (valuesFromVector (Proxy @sym)) (fmap SCB.breakpointArguments mbp) of
+        Some Ctx.Empty -> do
+          let st = SuspendedState { suspendedSymState = surveyorSymState
+                                  , suspendedSimState = crucSimState
+                                  , suspendedCallFrame = cf
+                                  , suspendedBreakpoint = mbp
+                                  , suspendedRegVals = Ctx.empty
+                                  , suspendedRegSelection = Nothing
+                                  }
+          return (Suspended st)
+        Some valAssignment@(_ Ctx.:> _) -> do
+          let anIndex = Ctx.lastIndex (Ctx.size valAssignment)
+          let st = SuspendedState { suspendedSymState = surveyorSymState
+                                  , suspendedSimState = crucSimState
+                                  , suspendedCallFrame = cf
+                                  , suspendedBreakpoint = mbp
+                                  , suspendedRegVals = valAssignment
+                                  , suspendedRegSelection = Just (Some anIndex)
+                                  }
+          return (Suspended st)
+
+  where
+    bpName :: T.Text
+    bpName = fromMaybe "<Unnamed Breakpoint>" (SCB.breakpointName =<< mbp)
+    topFrame = crucSimState ^. CSET.stateTree . CSET.actFrame
+
+valuesFromVector :: proxy sym
+                 -> DV.Vector (LCSR.RegValue sym LCT.AnyType)
+                 -> Some (Ctx.Assignment (LMCR.RegEntry sym))
+valuesFromVector _ v = go 0 (Some Ctx.empty)
+  where
+    go idx (Some ctx)
+      | idx >= DV.length v = Some ctx
+      | otherwise =
+        case v DV.! idx of
+          LCSR.AnyValue tp val ->
+            go (idx + 1) (Some (Ctx.extend ctx (LMCR.RegEntry tp val)))
+
 
 instance NFData (SymbolicExecutionState arch s k) where
   rnf s =
@@ -149,7 +228,7 @@ instance NFData (SymbolicExecutionState arch s k) where
         symState `seq` ()
       Executing progress -> progress `deepseq` ()
       Inspecting metrics symState res -> metrics `seq` symState `seq` res `seq` ()
-      Suspended symState _ _ -> symState `seq` ()
+      Suspended symState -> symState `seq` ()
 
 -- | A wrapper around all of the dynamically updatable symbolic execution state
 --
@@ -223,7 +302,7 @@ symbolicExecutionConfig s =
     Initializing s' -> symbolicConfig s'
     Executing s' -> executionConfig s'
     Inspecting _ s' _ -> symbolicConfig s'
-    Suspended s' _ _ -> symbolicConfig s'
+    Suspended s' -> symbolicConfig (suspendedSymState s')
 
 symbolicSessionID :: SymbolicExecutionState arch s k -> SessionID s
 symbolicSessionID s = symbolicExecutionConfig s L.^. sessionID

--- a/surveyor-core/src/Surveyor/Core/SymbolicExecution.hs
+++ b/surveyor-core/src/Surveyor/Core/SymbolicExecution.hs
@@ -87,6 +87,7 @@ import qualified What4.Symbol as WS
 import qualified What4.Utils.StringLiteral as WUS
 
 import qualified Surveyor.Core.Architecture as CA
+import qualified Surveyor.Core.Breakpoint as SCB
 import qualified Surveyor.Core.Chan as SCC
 import qualified Surveyor.Core.Events as SCE
 import qualified Surveyor.Core.Panic as SCP
@@ -132,6 +133,7 @@ data SymbolicExecutionState arch s (k :: SymExK) where
   Suspended :: (CB.IsSymInterface sym, ext ~ CA.CrucibleExt arch, CA.Architecture arch s)
             => SymbolicState arch s sym init reg
             -> CSET.SimState p sym ext rtp f a
+            -> Maybe (SCB.Breakpoint sym)
             -> SymbolicExecutionState arch s Suspend
 
 instance NFData (SymbolicExecutionState arch s k) where
@@ -143,7 +145,7 @@ instance NFData (SymbolicExecutionState arch s k) where
         symState `seq` ()
       Executing progress -> progress `deepseq` ()
       Inspecting metrics symState res -> metrics `seq` symState `seq` res `seq` ()
-      Suspended symState _ -> symState `seq` ()
+      Suspended symState _ _ -> symState `seq` ()
 
 -- | A wrapper around all of the dynamically updatable symbolic execution state
 --
@@ -217,7 +219,7 @@ symbolicExecutionConfig s =
     Initializing s' -> symbolicConfig s'
     Executing s' -> executionConfig s'
     Inspecting _ s' _ -> symbolicConfig s'
-    Suspended s' _ -> symbolicConfig s'
+    Suspended s' _ _ -> symbolicConfig s'
 
 symbolicSessionID :: SymbolicExecutionState arch s k -> SessionID s
 symbolicSessionID s = symbolicExecutionConfig s L.^. sessionID

--- a/surveyor-core/src/Surveyor/Core/SymbolicExecution.hs
+++ b/surveyor-core/src/Surveyor/Core/SymbolicExecution.hs
@@ -130,7 +130,11 @@ data SymbolicExecutionState arch s (k :: SymExK) where
                                 (CA.CrucibleExt arch)
                                 (CS.RegEntry sym reg)
              -> SymbolicExecutionState arch s Inspect
-  Suspended :: (CB.IsSymInterface sym, ext ~ CA.CrucibleExt arch, CA.Architecture arch s)
+  Suspended :: ( CB.IsSymInterface sym
+               , CA.Architecture arch s
+               , ext ~ CA.CrucibleExt arch
+               , sym ~ WEB.ExprBuilder s st fs
+               )
             => SymbolicState arch s sym init reg
             -> CSET.SimState p sym ext rtp f a
             -> Maybe (SCB.Breakpoint sym)

--- a/surveyor-core/surveyor-core.cabal
+++ b/surveyor-core/surveyor-core.cabal
@@ -27,6 +27,7 @@ library
                        Surveyor.Core.Arguments
                        Surveyor.Core.Async
                        Surveyor.Core.BinaryAnalysisResult
+                       Surveyor.Core.Breakpoint
                        Surveyor.Core.Chan
                        Surveyor.Core.Command
                        Surveyor.Core.Commands


### PR DESCRIPTION
This PR is progress on #19.  The skeleton of the viewer is in place, and it is mostly a matter of finishing filling out the rendering cases.  This PR also includes a tweak to the breakpoint override to let it "capture" simulation-time values for visualization.

The new widget is not hooked up yet, and in fact will almost certainly require some upstream changes to be successfully hooked up (we need to know that `sym ~ ExprBuilder` in order to traverse terms for rendering.