### PR TITLE
Generalize the selection for the value viewer

### DIFF
--- a/surveyor-brick/src/Surveyor/Brick/Widget/CallStackViewer.hs
+++ b/surveyor-brick/src/Surveyor/Brick/Widget/CallStackViewer.hs
@@ -8,62 +8,178 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE TypeApplications #-}
 -- | A viewer for Crucible call stacks (from a suspended symbolic execution)
 module Surveyor.Brick.Widget.CallStackViewer (
   CallStackViewer,
   callStackViewer,
+  frameList,
+  selectedValue,
   renderCallStackViewer,
   handleCallStackViewerEvent
   ) where
 
 import qualified Brick as B
+import qualified Brick.Focus as BF
 import qualified Brick.Widgets.List as BL
-import           Control.Lens ( (^.) )
+import           Control.Lens ( (^.), (&), (.~), (%~) )
 import qualified Control.Lens as L
+import           Data.Maybe ( fromMaybe )
+import qualified Data.Parameterized.Classes as PC
+import qualified Data.Parameterized.Context as Ctx
 import           Data.Parameterized.Some ( Some(..) )
+import qualified Data.Parameterized.TraversableFC as FC
 import           Data.Proxy ( Proxy(..) )
+import qualified Data.Text as T
 import qualified Data.Vector as DV
+import qualified Graphics.Vty as GV
 import qualified Lang.Crucible.CFG.Core as LCCC
 import qualified Lang.Crucible.FunctionHandle as CFH
 import qualified Lang.Crucible.Simulator.CallFrame as LCSC
 import qualified Lang.Crucible.Simulator.ExecutionTree as LCSET
+import qualified Lang.Crucible.Simulator.RegMap as LMCR
+import qualified What4.Expr.Builder as WEB
 import qualified What4.FunctionName as WFN
 
 import qualified Surveyor.Brick.Names as SBN
+import qualified Surveyor.Brick.Widget.ValueSelector as SBV
+import qualified Surveyor.Brick.Widget.ValueViewer as WVV
 import qualified Surveyor.Core as SC
 
-data CallStackViewer arch s where
-  CallStackViewer :: CallStackViewerState sym arch s -> CallStackViewer arch s
+-- | A type to let us distinguish between breakpoint frames and normal call
+-- frames, while treating them relatively uniformly.
+data CallStackEntry arch s sym where
+  BreakpointFrame :: Maybe T.Text -> CallStackEntry arch s sym
+  CallFrame :: LCSC.SimFrame sym (SC.CrucibleExt arch) l args -> CallStackEntry arch s sym
 
-data CallStackViewerState sym arch s =
-  CallStackViewerState { frameList :: BL.GenericList SBN.Names DV.Vector (LCSET.SomeFrame (LCSC.SimFrame sym (SC.CrucibleExt arch)))
-                       , proxy :: Proxy arch
-                       }
+-- | Another type wrapper that adds a phantom type parameter so that we can
+-- store 'WVV.ValueViewer's in 'Ctx.Assignment's.  It isn't strictly necessary
+-- to do so, but it gives us total indexing where a Map would not.
+data WrappedViewer s sym (tp :: LCCC.CrucibleType) where
+  WrappedViewer :: WVV.ValueViewer s sym -> WrappedViewer s sym tp
+
+-- | A collection of all of the state we track for a call frame (including breakpoints)
+--
+--  - The 'CallStackEntry' marks the frame as either the breakpoint frame or one
+--    of the special frame types maintained by Crucible
+--  - The 'SBV.ValueSelectorForm' is a form that allows the user to select the
+--    value they want to view out of the current frame
+--  - The 'Ctx.Assignment' caches the 'WVV.ValueViewer' widgets constructed for each viewable value
+--
+-- The former two are tracked and cached so that they don't need to be rebuilt
+-- and to preserve any state that is built up (i.e., so that switching between
+-- stack entries doesn't discard user selection states).
+data CallStackFrame arch s sym e where
+  CallStackFrame :: CallStackEntry arch s sym
+                 -> SBV.ValueSelectorForm s sym ctx e
+                 -> Ctx.Assignment (WrappedViewer s sym) ctx
+                 -> CallStackFrame arch s sym e
+
+data CallStackViewer arch s sym e =
+  CallStackViewer { _frameList :: BL.GenericList SBN.Names DV.Vector (CallStackFrame arch s sym e)
+                  , _focusRing :: BF.FocusRing SBN.Names
+                  }
+
+L.makeLenses ''CallStackViewer
 
 -- | Construct the viewer widget from a callstack
 --
 -- Future developments should be able to inspect the registers for each call
 -- frame (as if they were the breakpoint registers)
-callStackViewer :: forall proxy arch sym s
-                 . proxy arch
+callStackViewer :: forall proxy arch sym s ctx e st fs
+                 . (sym ~ WEB.ExprBuilder s st fs)
+                => proxy arch
+                -> Maybe T.Text
+                -- ^ Breakpoint name
+                -> Ctx.Assignment (LMCR.RegEntry sym) ctx
+                -- ^ Breakpoint captured values
                 -> [LCSET.SomeFrame (LCSC.SimFrame sym (SC.CrucibleExt arch))]
-                -> CallStackViewer arch s
-callStackViewer _ frames = CallStackViewer vs
+                -- ^ Frames on the stack of the symbolic execution engine
+                -> CallStackViewer arch s sym e
+callStackViewer proxy bpName bpVals simFrames = CallStackViewer frmList fr
   where
+    bpEntry = BreakpointFrame bpName
+    bpViewers = FC.fmapFC regViewer bpVals
+    bpFrame = CallStackFrame bpEntry (SBV.valueSelectorForm bpVals) bpViewers
+    frames = bpFrame : map (fromSimFrame proxy) simFrames
     frmList = BL.list SBN.CallStackViewer (DV.fromList frames) 1
-    vs = CallStackViewerState { frameList = frmList
-                              , proxy = Proxy @arch
-                              }
 
-renderCallStackViewer :: Bool -> CallStackViewer arch s -> B.Widget SBN.Names
-renderCallStackViewer hasFocus (CallStackViewer vs) =
-  B.vBox [ B.txt "Call Stack"
-         , BL.renderList (renderSomeFrame (proxy vs)) hasFocus (frameList vs)
+    fr = BF.focusRing [ SBN.CallStackViewer, SBN.BreakpointValueSelectorForm, SBN.BreakpointValueViewer ]
+
+fromSimFrame :: (sym ~ WEB.ExprBuilder s st fs)
+             => proxy arch
+             -> LCSET.SomeFrame (LCSC.SimFrame sym (SC.CrucibleExt arch))
+             -> CallStackFrame arch s sym e
+fromSimFrame proxy (LCSET.SomeFrame sf) =
+  withFrameRegs proxy sf $ \regs ->
+    let viewers = FC.fmapFC regViewer regs
+    in CallStackFrame entry (SBV.valueSelectorForm regs) viewers
+  where
+    entry = CallFrame sf
+
+withFrameRegs :: proxy arch
+              -> LCSC.SimFrame sym (SC.CrucibleExt arch) l args
+              -> (forall ctx . Ctx.Assignment (LMCR.RegEntry sym) ctx -> a)
+              -> a
+withFrameRegs _ sf k =
+  case sf of
+    LCSC.OF oframe -> k (oframe ^. LCSC.overrideRegMap . L.to LMCR.regMap)
+    LCSC.MF mframe -> k (mframe ^. LCSC.frameRegs . L.to LMCR.regMap)
+    LCSC.RF _name e -> k (Ctx.Empty Ctx.:> e)
+
+regViewer :: (sym ~ WEB.ExprBuilder s st fs)
+          => LMCR.RegEntry sym tp
+          -> WrappedViewer s sym tp
+regViewer re = WrappedViewer (WVV.valueViewer (LMCR.regType re) (LMCR.regValue re))
+
+renderCallStackViewer :: forall arch s sym e st fs
+                       . (sym ~ WEB.ExprBuilder s st fs)
+                      => Bool
+                      -> SC.ValueNameMap s
+                      -> CallStackViewer arch s sym e
+                      -> B.Widget SBN.Names
+renderCallStackViewer hasFocus valNames cs =
+  B.hBox [ B.vBox [ B.txt "Call Stack"
+                  , BL.renderList (renderCallStackFrame (Proxy @arch)) (hasFocus && stackSelected) (cs ^. frameList)
+                  ]
+         , renderValueSelector (hasFocus && valSelSelected) (cs ^. frameList . L.to BL.listSelectedElement)
+         , renderSelectedValue (hasFocus && viewerSelected) valNames (cs ^. frameList . L.to BL.listSelectedElement)
          ]
+  where
+    curSel = cs ^. focusRing . L.to BF.focusGetCurrent
+    stackSelected = Just SBN.CallStackViewer == curSel
+    valSelSelected = Just SBN.BreakpointValueSelectorForm == curSel
+    viewerSelected = Just SBN.BreakpointValueViewer == curSel
 
-renderSomeFrame :: proxy arch -> Bool -> LCSET.SomeFrame (LCSC.SimFrame sym (SC.CrucibleExt arch)) -> B.Widget SBN.Names
-renderSomeFrame _ _hasFocus (LCSET.SomeFrame sf) =
+renderValueSelector :: Bool -> Maybe (Int, CallStackFrame arch s sym e) -> B.Widget SBN.Names
+renderValueSelector _hasFocus mf =
+  case mf of
+    Nothing -> B.emptyWidget
+    Just (_, CallStackFrame _ selForm _viewers) ->
+      SBV.renderValueSelectorForm selForm
+
+renderSelectedValue :: (sym ~ WEB.ExprBuilder s st fs)
+                    => Bool
+                    -> SC.ValueNameMap s
+                    -> Maybe (Int, CallStackFrame arch s sym e)
+                    -> B.Widget SBN.Names
+renderSelectedValue hasFocus valNames mf =
+  case mf of
+    Just (_, CallStackFrame _ selForm viewers)
+      | Just (Some idx) <- SBV.selectedIndex selForm
+      , WrappedViewer vv <- viewers Ctx.! idx ->
+        WVV.renderValueViewer hasFocus valNames vv
+    _ -> B.emptyWidget
+
+renderCallStackFrame :: proxy arch -> Bool -> CallStackFrame arch s sym e -> B.Widget SBN.Names
+renderCallStackFrame proxy hasFocus (CallStackFrame cse _ _) =
+  case cse of
+    BreakpointFrame mName -> B.txt (fromMaybe "<Unnamed Breakpoint>" mName)
+    CallFrame sf -> renderSomeFrame proxy hasFocus sf
+
+renderSomeFrame :: proxy arch -> Bool -> LCSC.SimFrame sym (SC.CrucibleExt arch) l args -> B.Widget SBN.Names
+renderSomeFrame _ _hasFocus sf =
   case sf of
     LCSC.OF oframe -> B.txt (oframe ^. LCSC.override . L.to WFN.functionName) B.<+> B.txt " (Override)"
     LCSC.MF cframe -> renderCallFrame cframe
@@ -83,11 +199,42 @@ renderBlockID :: Some (LCCC.BlockID blocks) -> B.Widget n
 renderBlockID (Some bid) = B.str (show bid)
 
 handleCallStackViewerEvent :: B.BrickEvent SBN.Names e
-                           -> CallStackViewer arch s
-                           -> B.EventM SBN.Names (CallStackViewer arch s)
-handleCallStackViewerEvent evt cs0@(CallStackViewer vs) =
+                           -> CallStackViewer arch s sym e
+                           -> B.EventM SBN.Names (CallStackViewer arch s sym e)
+handleCallStackViewerEvent evt cs0 =
   case evt of
-    B.VtyEvent ve -> do
-      fl' <- BL.handleListEvent ve (frameList vs)
-      return (CallStackViewer vs { frameList = fl' })
+    B.VtyEvent (GV.EvKey (GV.KChar '\t') []) ->
+      return (cs0 & focusRing %~ BF.focusNext)
+    B.VtyEvent ve
+      | BF.focusGetCurrent (cs0 ^. focusRing) == Just SBN.CallStackViewer -> do
+          fl' <- BL.handleListEvent ve (cs0 ^. frameList)
+          return (cs0 & frameList .~ fl')
+      | BF.focusGetCurrent (cs0 ^. focusRing) == Just SBN.BreakpointValueViewer
+      , Just (listIdx, CallStackFrame cse selForm viewers) <- cs0 ^. frameList . L.to BL.listSelectedElement
+      , Just (Some idx) <- SBV.selectedIndex selForm
+      , WrappedViewer vv <- viewers Ctx.! idx -> do
+          vv' <- WVV.handleValueViewerEvent ve vv
+          let frame = CallStackFrame cse selForm (L.set (PC.ixF idx) (WrappedViewer vv') viewers)
+          return (cs0 & frameList . BL.listElementsL %~ (DV.// [(listIdx, frame)]))
+      | BF.focusGetCurrent (cs0 ^. focusRing) == Just SBN.BreakpointValueSelectorForm
+      , Just (listIdx, CallStackFrame cse selForm viewers) <- cs0 ^. frameList . L.to BL.listSelectedElement -> do
+          selForm' <- SBV.handleValueSelectorFormEvent evt selForm
+          let frame = CallStackFrame cse selForm' viewers
+          return (cs0 & frameList . BL.listElementsL %~ (DV.// [(listIdx, frame)]))
     _ -> return cs0
+
+-- | Return the currently-selected value in the 'CallStackViewer'
+--
+-- If the user has selected a sub-value in the value viewer for the
+-- currently-selected top-level value, the value from the ValueViewer is
+-- returned.  Otherwise, the top-level value in the value selector is returned
+-- (if any).
+selectedValue :: (sym ~ WEB.ExprBuilder s st fs) => CallStackViewer arch s sym e -> Maybe (Some (LMCR.RegEntry sym))
+selectedValue csv = do
+  (_, CallStackFrame _cse selForm viewers) <- csv ^. frameList . L.to BL.listSelectedElement
+  Some selValIdx <- SBV.selectedIndex selForm
+  case viewers Ctx.! selValIdx of
+    WrappedViewer vv ->
+      case WVV.selectedValue vv of
+        Nothing -> SBV.selectedValue selForm
+        Just sre -> return sre

--- a/surveyor-brick/src/Surveyor/Brick/Widget/SymbolicExecution/StateExplorer.hs
+++ b/surveyor-brick/src/Surveyor/Brick/Widget/SymbolicExecution/StateExplorer.hs
@@ -14,25 +14,16 @@ module Surveyor.Brick.Widget.SymbolicExecution.StateExplorer (
   ) where
 
 import qualified Brick as B
-import qualified Brick.Focus as BF
-import           Brick.Forms ( (@@=) )
-import qualified Brick.Forms as B
 import           Control.Lens ( (^.) )
 import qualified Control.Lens as L
 import           Data.Maybe ( fromMaybe )
 import qualified Data.Parameterized.Classes as PC
-import qualified Data.Parameterized.Context as Ctx
 import qualified Data.Parameterized.Nonce as PN
-import           Data.Parameterized.Some ( Some(..) )
-import qualified Data.Parameterized.TraversableFC as FC
 import           Data.Proxy ( Proxy(..) )
 import qualified Data.Text as T
-import qualified Graphics.Vty as GV
 import qualified Lang.Crucible.CFG.Core as LCCC
 import qualified Lang.Crucible.Simulator.CallFrame as LCSC
 import qualified Lang.Crucible.Simulator.ExecutionTree as LCSET
-import qualified Lang.Crucible.Simulator.RegMap as LMCR
-import qualified Lang.Crucible.Types as LCT
 import qualified What4.Expr.Builder as WEB
 
 import           Surveyor.Brick.Names ( Names(..) )
@@ -40,62 +31,17 @@ import qualified Surveyor.Brick.Panic as SBP
 import qualified Surveyor.Core as C
 
 import qualified Surveyor.Brick.Widget.CallStackViewer as WCSV
-import qualified Surveyor.Brick.Widget.ValueViewer as WVV
-
--- | This is a wrapper around a symbolic-execution time value (a RegEntry).  The
--- wrapper is helpful for hiding the @sym@ type parameter while still leaving
--- 'ValueSelector' as a plain data type (so lenses and brick still work).
---
--- While we hide the parameter, we do record the concrete symbolic backend type
--- so that we can traverse terms.
---
--- While this quantification is useful for now, it is problematic when we need
--- to use any of this information with values taken from the symbolic execution
--- state, which has separately quantified it all out.  To accommodate that use
--- case, we store a nonce to let us dynamically ensure that we have the correct
--- symbolic backend.  It should be impossible for them to not match.
-data RegWrapper s tp where
-  RegWrapper :: (sym ~ WEB.ExprBuilder s st fs) => PN.Nonce s sym -> LMCR.RegEntry (WEB.ExprBuilder s st fs) tp -> RegWrapper s tp
-
--- | This is a type capturing the data necessary to render the value selector form
---
--- We have to carefully quantify type parameters so that we can mesh well with brick.
-data ValueSelector s ctx =
-  ValueSelector { _values :: Ctx.Assignment (RegWrapper s) ctx
-                , _index :: Some (Ctx.Index ctx)
-                }
-
-L.makeLenses ''ValueSelector
-
--- | This wrapper quantifies out the ctx parameter from the form so that we can
--- return it
-data ValueSelectorForm s ctx e where
-  -- | A degenerate constructor in the case where the breakpoint captured no
-  -- values.  We need this, as we cannot construct a value of type
-  -- 'ValueSelector' if there are no entries in the list (since we would not be
-  -- able to construct an 'Ctx.Index' into the empty 'Ctx.Assignment')
-  NoValues :: ValueSelectorForm s ctx e
-  -- | A form that tracks the state of the currently selected value.  The data
-  -- payload of the form is the 'ValueSelector', which tells us the currently
-  -- selected index (which is a valid index into the list of 'WrappedViewer's in
-  -- the 'StateExplorer')
-  ValueSelectorForm :: B.Form (ValueSelector s ctx) e Names -> ValueSelectorForm s ctx e
-
--- | Another type wrapper that adds a phantom type parameter so that we can
--- store 'WVV.ValueViewer's in 'Ctx.Assignment's.  It isn't strictly necessary
--- to do so, but it gives us total indexing where a Map would not.
-data WrappedViewer s (tp :: LCCC.CrucibleType) where
-  WrappedViewer :: WVV.ValueViewer s -> WrappedViewer s tp
 
 -- | Holds the state of the StateExplorer widget
 --
 -- This includes the selected value state as well as the state for the value
--- viewer widget itself.
+-- viewer widget itself, all encapsulated in the 'WCSV.CallStackViewer'.  The
+-- nonce lets us prove that we have the same symbolic backend as the
+-- 'C.SymbolicExecutionState' so that we can move data between the two
 data StateExplorer arch s e where
-  StateExplorer :: ValueSelectorForm s ctx e
-                -> Ctx.Assignment (WrappedViewer s) ctx
-                -> BF.FocusRing Names
-                -> WCSV.CallStackViewer arch s
+  StateExplorer :: (sym ~ WEB.ExprBuilder s st fs)
+                => PN.Nonce s sym
+                -> WCSV.CallStackViewer arch s sym e
                 -> StateExplorer arch s e
 
 -- | Construct the necessary explorer state from a suspended symbolic execution state
@@ -118,34 +64,11 @@ stateExplorer :: forall e arch s
                . C.SymbolicExecutionState arch s C.Suspend
               -> StateExplorer arch s e
 stateExplorer (C.Suspended symNonce suspSt) =
-  case C.suspendedRegVals suspSt of
-    Ctx.Empty ->
-      let csv = WCSV.callStackViewer (Proxy @arch) (suspSt ^. L.to C.suspendedSimState . LCSET.stateTree . L.to LCSET.activeFrames)
-      in StateExplorer NoValues Ctx.Empty (BF.focusRing []) csv
-    vals@(_ Ctx.:> _) ->
-      let idxList = reverse $ Ctx.forIndex (Ctx.size vals) (\acc idx -> idxEntry idx : acc) []
-          wrappedVals = FC.fmapFC (RegWrapper symNonce) vals
-          vs = ValueSelector { _values = wrappedVals
-                             , _index = head idxList ^. L._1
-                             }
-          formCon = B.newForm [ (B.str "Breakpoint Value: " B.<+>) @@= B.radioField index idxList
-                              ]
-          vsf = ValueSelectorForm (formCon vs)
-
-          toValueViewer :: forall tp . RegWrapper s tp -> WrappedViewer s tp
-          toValueViewer (RegWrapper sn (re :: LMCR.RegEntry (WEB.ExprBuilder s st fs) tp)) =
-            case re of
-              LMCR.RegEntry tp rv
-                | Just PC.Refl <- PC.testEquality sn symNonce -> WrappedViewer (WVV.valueViewer symNonce tp rv)
-                | otherwise ->
-                  SBP.panic "stateExplorer" ["Symbolic backend nonce mismatch"]
-          viewers = FC.fmapFC toValueViewer wrappedVals
-          fr = BF.focusRing [BreakpointValueSelectorForm, BreakpointValueViewer, CallStackViewer]
-          csv = WCSV.callStackViewer (Proxy @arch) (suspSt ^. L.to C.suspendedSimState . LCSET.stateTree . L.to LCSET.activeFrames)
-      in StateExplorer vsf viewers fr csv
+  StateExplorer symNonce csViewer
   where
-    idxEntry :: forall tp (ctx :: Ctx.Ctx LCCC.CrucibleType) . Ctx.Index ctx tp -> (Some (Ctx.Index ctx), Names, T.Text)
-    idxEntry idx = (Some idx, SelectedBreakpointValue (Ctx.indexVal idx), T.pack (show idx))
+    bpName = suspSt ^. L.to C.suspendedBreakpoint . L._Just . L.to C.breakpointName
+    csViewer = WCSV.callStackViewer (Proxy @arch) bpName (C.suspendedRegVals suspSt) frames
+    frames = suspSt ^. L.to C.suspendedSimState . LCSET.stateTree . L.to LCSET.activeFrames
 
 -- | Render a view of the final state from symbolic execution
 --
@@ -155,40 +78,16 @@ renderSymbolicExecutionStateExplorer :: forall arch s e
                                       . (C.SymbolicExecutionState arch s C.Suspend, StateExplorer arch s e)
                                      -> C.ValueNameMap s
                                      -> B.Widget Names
-renderSymbolicExecutionStateExplorer (C.Suspended _symNonce suspSt, se@(StateExplorer vsf _viewers focus csv)) valNames =
+renderSymbolicExecutionStateExplorer (C.Suspended _symNonce1 suspSt, StateExplorer _symNonce2 csv) valNames =
   case C.suspendedCallFrame suspSt of
     cf@LCSC.CallFrame { LCSC._frameCFG = fcfg } ->
       B.vBox [ B.txt "Current Function:" B.<+> B.txt (T.pack (show (LCCC.cfgHandle fcfg)))
-           , B.txt "Current Block:" B.<+> B.txt (T.pack (show (cf ^. LCSC.frameBlockID)))
-           , B.txt "Breakpoint name:" B.<+> B.txt (fromMaybe "<Unnamed Breakpoint>" (C.breakpointName =<< mbp))
-           , B.hBox[ renderBreakpointValueSelector vsf
-                   , B.fill ' '
-                   , WCSV.renderCallStackViewer (BF.focusGetCurrent focus == Just CallStackViewer) csv
-                   ]
-           , renderSelectedValue valNames se
-           ]
+             , B.txt "Current Block:" B.<+> B.txt (T.pack (show (cf ^. LCSC.frameBlockID)))
+             , B.txt "Breakpoint name:" B.<+> B.txt (fromMaybe "<Unnamed Breakpoint>" (C.breakpointName =<< mbp))
+             , WCSV.renderCallStackViewer True valNames csv
+             ]
   where
     mbp = C.suspendedBreakpoint suspSt
-
-renderBreakpointValueSelector :: ValueSelectorForm s ctx e
-                              -> B.Widget Names
-renderBreakpointValueSelector vsf =
-  case vsf of
-    NoValues -> B.emptyWidget
-    ValueSelectorForm f -> B.renderForm f
-
-renderSelectedValue :: forall arch s e
-                     . C.ValueNameMap s
-                    -> StateExplorer arch s e
-                    -> B.Widget Names
-renderSelectedValue valNames (StateExplorer vsf viewers focus _csv) =
-  case vsf of
-    NoValues -> B.emptyWidget
-    ValueSelectorForm f
-      | Some idx <- f ^. L.to B.formState . index
-      , WrappedViewer vv <- viewers Ctx.! idx ->
-          let isFocused = BF.focusGetCurrent focus == Just BreakpointValueViewer
-          in WVV.renderValueViewer isFocused valNames vv
 
 -- | Handle events for the 'StateExplorer'
 --
@@ -197,44 +96,10 @@ renderSelectedValue valNames (StateExplorer vsf viewers focus _csv) =
 handleSymbolicExecutionStateExplorerEvent :: B.BrickEvent Names e
                                           -> (C.SymbolicExecutionState arch s C.Suspend, StateExplorer arch s e)
                                           -> B.EventM Names (C.SymbolicExecutionState arch s C.Suspend, StateExplorer arch s e)
-handleSymbolicExecutionStateExplorerEvent evt s0@(C.Suspended symNonce suspSt, StateExplorer vsf viewers focus csv) =
-  case evt of
-    B.VtyEvent (GV.EvKey (GV.KChar '\t') []) ->
-      return (C.Suspended symNonce suspSt, StateExplorer vsf viewers (BF.focusNext focus) csv)
-    B.VtyEvent ve ->
-      case BF.focusGetCurrent focus of
-        Just CallStackViewer -> do
-          csv' <- WCSV.handleCallStackViewerEvent evt csv
-          return (C.Suspended symNonce suspSt, StateExplorer vsf viewers focus csv')
-        _ ->
-          case vsf of
-            NoValues ->
-              -- If there is no index, that is only because there are no breakpoint
-              -- values (and therefore nothing to select and no events to handle)
-              return s0
-            ValueSelectorForm f ->
-              case BF.focusGetCurrent focus of
-                Just BreakpointValueSelectorForm -> do
-                  f' <- B.handleFormEvent evt f
-                  let vs = B.formState f'
-                  case vs ^. index of
-                    Some idx
-                      | RegWrapper regNonce re <- (vs ^. values) Ctx.! idx -> do
-                          case PC.testEquality regNonce symNonce of
-                            Just PC.Refl -> do
-                              let suspSt' = suspSt { C.suspendedCurrentValue = Just (Some re) }
-                              return (C.Suspended symNonce suspSt', StateExplorer (ValueSelectorForm f') viewers focus csv)
-                            Nothing ->
-                              SBP.panic "handleSymbolicExecutionExplorerEvent" ["Mismatched solver nonce"]
-                Just BreakpointValueViewer
-                  | Some idx <- f ^. L.to B.formState . index
-                  , WrappedViewer valView <- viewers Ctx.! idx -> do
-                      v' <- WVV.handleValueViewerEvent ve valView
-                      let suspSt' = suspSt { C.suspendedCurrentValue = exprToRegEntry <$> WVV.selectedValue symNonce v' }
-                      let viewers' = L.set (PC.ixF idx) (WrappedViewer v') viewers
-                      return (C.Suspended symNonce suspSt', StateExplorer vsf viewers' focus csv)
-                n -> SBP.panic "handleSymbolicExecutionExplorerEvent" ["Unexpected component in focus ring: " ++ show n]
-    _ -> return s0
-
-exprToRegEntry :: Some (WEB.Expr s) -> Some (LMCR.RegEntry (WEB.ExprBuilder s st fs))
-exprToRegEntry (Some e) = Some (LMCR.RegEntry (LCT.baseToType (WEB.exprType e)) e)
+handleSymbolicExecutionStateExplorerEvent evt (C.Suspended symNonce1 suspSt, StateExplorer symNonce2 csv) = do
+  case PC.testEquality symNonce1 symNonce2 of
+    Nothing -> SBP.panic "handleSymbolicExecutionExplorerEvent" ["Mismatched solver nonce"]
+    Just PC.Refl -> do
+      csv' <- WCSV.handleCallStackViewerEvent evt csv
+      let suspSt' = suspSt { C.suspendedCurrentValue = WCSV.selectedValue csv' }
+      return (C.Suspended symNonce1 suspSt', StateExplorer symNonce2 csv')

--- a/surveyor-brick/src/Surveyor/Brick/Widget/ValueSelector.hs
+++ b/surveyor-brick/src/Surveyor/Brick/Widget/ValueSelector.hs
@@ -25,21 +25,6 @@ import qualified Lang.Crucible.Simulator.RegMap as LMCR
 
 import qualified Surveyor.Brick.Names as SBN
 
--- | This is a wrapper around a symbolic-execution time value (a RegEntry).  The
--- wrapper is helpful for hiding the @sym@ type parameter while still leaving
--- 'ValueSelector' as a plain data type (so lenses and brick still work).
---
--- While we hide the parameter, we do record the concrete symbolic backend type
--- so that we can traverse terms.
---
--- While this quantification is useful for now, it is problematic when we need
--- to use any of this information with values taken from the symbolic execution
--- state, which has separately quantified it all out.  To accommodate that use
--- case, we store a nonce to let us dynamically ensure that we have the correct
--- symbolic backend.  It should be impossible for them to not match.
--- data RegWrapper s tp where
---   RegWrapper :: (sym ~ WEB.ExprBuilder s st fs) => PN.Nonce s sym -> LMCR.RegEntry (WEB.ExprBuilder s st fs) tp -> RegWrapper s tp
-
 -- | This is a type capturing the data necessary to render the value selector form
 --
 -- We have to carefully quantify type parameters so that we can mesh well with brick.

--- a/surveyor-brick/src/Surveyor/Brick/Widget/ValueSelector.hs
+++ b/surveyor-brick/src/Surveyor/Brick/Widget/ValueSelector.hs
@@ -1,0 +1,111 @@
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE TypeOperators #-}
+module Surveyor.Brick.Widget.ValueSelector (
+  ValueSelector,
+  ValueSelectorForm,
+  valueSelectorForm,
+  selectedIndex,
+  selectedValue,
+  renderValueSelectorForm,
+  handleValueSelectorFormEvent
+  ) where
+
+import qualified Brick as B
+import           Brick.Forms ( (@@=) )
+import qualified Brick.Forms as B
+import           Control.Lens ( (^.) )
+import qualified Control.Lens as L
+import qualified Data.Parameterized.Context as Ctx
+import           Data.Parameterized.Some ( Some(..) )
+import qualified Data.Text as T
+import qualified Lang.Crucible.Simulator.RegMap as LMCR
+
+import qualified Surveyor.Brick.Names as SBN
+
+-- | This is a wrapper around a symbolic-execution time value (a RegEntry).  The
+-- wrapper is helpful for hiding the @sym@ type parameter while still leaving
+-- 'ValueSelector' as a plain data type (so lenses and brick still work).
+--
+-- While we hide the parameter, we do record the concrete symbolic backend type
+-- so that we can traverse terms.
+--
+-- While this quantification is useful for now, it is problematic when we need
+-- to use any of this information with values taken from the symbolic execution
+-- state, which has separately quantified it all out.  To accommodate that use
+-- case, we store a nonce to let us dynamically ensure that we have the correct
+-- symbolic backend.  It should be impossible for them to not match.
+-- data RegWrapper s tp where
+--   RegWrapper :: (sym ~ WEB.ExprBuilder s st fs) => PN.Nonce s sym -> LMCR.RegEntry (WEB.ExprBuilder s st fs) tp -> RegWrapper s tp
+
+-- | This is a type capturing the data necessary to render the value selector form
+--
+-- We have to carefully quantify type parameters so that we can mesh well with brick.
+data ValueSelector sym ctx =
+  ValueSelector { _values :: Ctx.Assignment (LMCR.RegEntry sym) ctx
+                , _index :: Some (Ctx.Index ctx)
+                }
+
+L.makeLenses ''ValueSelector
+
+selectedIndex :: ValueSelectorForm s sym ctx e -> Maybe (Some (Ctx.Index ctx))
+selectedIndex vs =
+  case vs of
+    NoValues -> Nothing
+    ValueSelectorForm f -> Just (f ^. L.to B.formState . index)
+
+selectedValue :: ValueSelectorForm s sym ctx e -> Maybe (Some (LMCR.RegEntry sym))
+selectedValue vs =
+  case vs of
+    NoValues -> Nothing
+    ValueSelectorForm f ->
+      case f ^. L.to B.formState . index of
+        Some idx -> Just (Some ((f ^. L.to B.formState . values) Ctx.! idx))
+
+-- | This wrapper quantifies out the ctx parameter from the form so that we can
+-- return it
+data ValueSelectorForm s sym ctx e where
+  -- | A degenerate constructor in the case where the breakpoint captured no
+  -- values.  We need this, as we cannot construct a value of type
+  -- 'ValueSelector' if there are no entries in the list (since we would not be
+  -- able to construct an 'Ctx.Index' into the empty 'Ctx.Assignment')
+  NoValues :: ValueSelectorForm s sym Ctx.EmptyCtx e
+  -- | A form that tracks the state of the currently selected value.  The data
+  -- payload of the form is the 'ValueSelector', which tells us the currently
+  -- selected index (which is a valid index into the list of 'WrappedViewer's in
+  -- the 'StateExplorer')
+  --
+  -- We carry a proof that the context is not empty
+  ValueSelectorForm :: (ctx ~ (ctx0 Ctx.::> tp)) => B.Form (ValueSelector sym ctx) e SBN.Names -> ValueSelectorForm s sym ctx e
+
+valueSelectorForm :: forall s sym ctx e
+                   . Ctx.Assignment (LMCR.RegEntry sym) ctx
+                  -> ValueSelectorForm s sym ctx e
+valueSelectorForm entries =
+  case entries of
+    Ctx.Empty -> NoValues
+    vals@(_ Ctx.:> _) ->
+      let idxList = reverse $ Ctx.forIndex (Ctx.size vals) (\acc idx -> idxEntry idx : acc) []
+          vs = ValueSelector { _values = vals, _index = head idxList ^. L._1 }
+          formCon = B.newForm [ (B.str "Value: " B.<+>) @@= B.radioField index idxList
+                              ]
+      in ValueSelectorForm (formCon vs)
+  where
+    idxEntry :: forall tp . Ctx.Index ctx tp -> (Some (Ctx.Index ctx), SBN.Names, T.Text)
+    idxEntry idx = (Some idx, SBN.SelectedBreakpointValue (Ctx.indexVal idx), T.pack (show idx))
+
+renderValueSelectorForm :: ValueSelectorForm s sym ctx e -> B.Widget SBN.Names
+renderValueSelectorForm vsf =
+  case vsf of
+    NoValues -> B.txt "No values in frame"
+    ValueSelectorForm f -> B.renderForm f
+
+handleValueSelectorFormEvent :: B.BrickEvent SBN.Names e
+                             -> ValueSelectorForm s sym ctx e
+                             -> B.EventM SBN.Names (ValueSelectorForm s sym ctx e)
+handleValueSelectorFormEvent evt vsf =
+  case vsf of
+    NoValues -> return NoValues
+    ValueSelectorForm f -> ValueSelectorForm <$> B.handleFormEvent evt f

--- a/surveyor-brick/src/Surveyor/Brick/Widget/ValueViewer.hs
+++ b/surveyor-brick/src/Surveyor/Brick/Widget/ValueViewer.hs
@@ -64,7 +64,6 @@ data ValueViewerState s sym tp =
                    -- ^ The state of the Brick list we use to render values
                    --
                    -- This tracks things like selection state
-                   -- , vsSymNonce :: PN.Nonce s sym
                    }
 
 -- | Get the value that the user has selected in the 'ValueViewer' widget, if any

--- a/surveyor-brick/src/Surveyor/Brick/Widget/ValueViewer.hs
+++ b/surveyor-brick/src/Surveyor/Brick/Widget/ValueViewer.hs
@@ -25,7 +25,6 @@ import qualified Control.Monad.State.Strict as St
 import qualified Data.BitVector.Sized as DBS
 import qualified Data.List as L
 import           Data.Maybe ( fromMaybe )
-import qualified Data.Parameterized.Classes as PC
 import qualified Data.Parameterized.Map as MapF
 import qualified Data.Parameterized.Nonce as PN
 import           Data.Parameterized.Some ( Some(..) )
@@ -34,6 +33,7 @@ import qualified Data.Text as T
 import qualified Data.Vector as DV
 import qualified Graphics.Vty as GV
 import qualified Lang.Crucible.LLVM.MemModel as CLM
+import qualified Lang.Crucible.Simulator.RegMap as LMCR
 import qualified Lang.Crucible.Simulator.RegValue as LCSR
 import qualified Lang.Crucible.Types as LCT
 import           Text.Printf ( printf )
@@ -64,25 +64,24 @@ data ValueViewerState s sym tp =
                    -- ^ The state of the Brick list we use to render values
                    --
                    -- This tracks things like selection state
-                   , vsSymNonce :: PN.Nonce s sym
+                   -- , vsSymNonce :: PN.Nonce s sym
                    }
 
 -- | Get the value that the user has selected in the 'ValueViewer' widget, if any
 --
 -- NOTE: This only considers values with nonces
-selectedValue :: PN.Nonce s sym -> ValueViewer s -> Maybe (Some (WEB.Expr s))
-selectedValue symNonce (ValueViewer vs) = do
-  PC.Refl <- PC.testEquality symNonce (vsSymNonce vs)
+selectedValue :: (sym ~ WEB.ExprBuilder s st fs) => ValueViewer s sym -> Maybe (Some (LMCR.RegEntry sym))
+selectedValue (ValueViewer vs) = do
   (_ix, RenderWidget { rwValue = mval }) <- BL.listSelectedElement (valueList vs)
   val <- mval
-  return (Some val)
+  return (Some (LMCR.RegEntry (LCT.baseToType (WEB.exprType val)) val))
 
 
 -- | A widget state backing the value viewer; it existentially quantifies away
 -- the type and symbolic backend, with the real data storage in
 -- 'ValueViewerState'
-data ValueViewer s where
-  ValueViewer :: (sym ~ WEB.ExprBuilder s st fs) => ValueViewerState s sym tp -> ValueViewer s
+data ValueViewer s sym where
+  ValueViewer :: ValueViewerState s sym tp -> ValueViewer s sym
 
 -- | Construct a 'ValueViewer' for a single value
 --
@@ -99,12 +98,11 @@ data ValueViewer s where
 -- 'buildViewer')
 valueViewer :: forall sym tp s st fs
              . (sym ~ WEB.ExprBuilder s st fs)
-            => PN.Nonce s sym
-            -> LCT.TypeRepr tp
+            => LCT.TypeRepr tp
             -> LCSR.RegValue sym tp
-            -> ValueViewer s
-valueViewer p tp re =
-  St.evalState (unViewBuilder (buildViewer p tp re)) MapF.empty
+            -> ValueViewer s sym
+valueViewer tp re =
+  St.evalState (unViewBuilder (buildViewer tp re)) MapF.empty
 
 -- | A wrapper around a 'Rendering' that (possibly) includes program location
 -- information.
@@ -118,7 +116,7 @@ valueViewer p tp re =
 data RenderWidget sym =
   forall tp .
   RenderWidget { rwRendering :: Rendering
-               , rwLocation :: Maybe WPL.ProgramLoc
+               , _rwLocation :: Maybe WPL.ProgramLoc
                , rwValue :: Maybe (WI.SymExpr sym tp)
                }
 
@@ -154,11 +152,10 @@ newtype ViewerBuilder s sym a =
 -- Values without nonces are always rendered inline.
 buildViewer :: forall sym tp s st fs
              . (sym ~ WEB.ExprBuilder s st fs)
-            => PN.Nonce s sym
-            -> LCT.TypeRepr tp
+            => LCT.TypeRepr tp
             -> LCSR.RegValue sym tp
-            -> ViewerBuilder s sym (ValueViewer s)
-buildViewer symNonce tp re = do
+            -> ViewerBuilder s sym (ValueViewer s sym)
+buildViewer tp re = do
   -- Traverse the whole term initially to cache any widgets we can based on nonces.
   --
   -- We'll use this same primitive for rendering later, but then we'll start it
@@ -170,7 +167,6 @@ buildViewer symNonce tp re = do
                              , regValue = re
                              , cache = c
                              , rootWidget = renderedWidget root
-                             , vsSymNonce = symNonce
                              , valueList = BL.list ValueViewerList vals 1
                              }
   return (ValueViewer vvs)
@@ -544,9 +540,7 @@ argRef rw =
     RenderInline w -> w
     RenderBound r _ -> r
 
--- lookupValueName nonce vmap
-
-renderValueViewer :: Bool -> C.ValueNameMap s -> ValueViewer s -> B.Widget Names
+renderValueViewer :: (sym ~ WEB.ExprBuilder s st fs) => Bool -> C.ValueNameMap s -> ValueViewer s sym -> B.Widget Names
 renderValueViewer viewerFocused valNames (ValueViewer vs) =
   B.vBox [ BL.renderList render viewerFocused (valueList vs)
          , renderSelectedLocation
@@ -587,8 +581,8 @@ exprNonce val =
     WEB.SemiRingLiteral {} -> Nothing
 
 handleValueViewerEvent :: GV.Event
-                       -> ValueViewer s
-                       -> B.EventM Names (ValueViewer s)
+                       -> ValueViewer s sym
+                       -> B.EventM Names (ValueViewer s sym)
 handleValueViewerEvent evt (ValueViewer vs) = do
   l' <- BL.handleListEvent evt (valueList vs)
   return (ValueViewer vs { valueList = l' })

--- a/surveyor-brick/surveyor-brick.cabal
+++ b/surveyor-brick/surveyor-brick.cabal
@@ -30,6 +30,7 @@ library
                        Surveyor.Brick.Widget.SymbolicExecution.Monitor
                        Surveyor.Brick.Widget.SymbolicExecution.Setup
                        Surveyor.Brick.Widget.SymbolicExecution.StateExplorer
+                       Surveyor.Brick.Widget.ValueSelector
                        Surveyor.Brick.Widget.ValueViewer
                        Surveyor.Brick.Widget.CallStackViewer
                        Brick.Match.Subword


### PR DESCRIPTION
Now users can view values from not just the active breakpoint, but from any call frame in scope at the time the breakpoint fires.  This change also simplifies the state exploration code by keeping all of the existential quantification of symbolic backends at the top-level.  This ultimately also simplified the rendering of the three selection/viewing widgets.

Fixes #58 