### PR TITLE
Fix the symbolic execution configuration form

### DIFF
--- a/surveyor-brick/src/Surveyor/Brick/Widget/SymbolicExecution.hs
+++ b/surveyor-brick/src/Surveyor/Brick/Widget/SymbolicExecution.hs
@@ -70,9 +70,9 @@ handleSymbolicExecutionManagerEvent :: B.BrickEvent Names e
                                     -> B.EventM Names (SymbolicExecutionManager e arch s)
 handleSymbolicExecutionManagerEvent evt sem =
   case sem of
-    Configuring st f -> do
+    Configuring _st f -> do
       f' <- SEC.handleSymbolicExecutionConfiguratorEvent evt f
-      return (Configuring st f')
+      return (Configuring (C.Configuring (B.formState f')) f')
     Initializing st -> do
       st' <- SES.handleSymbolicExecutionSetupEvent evt st
       return (Initializing st')

--- a/surveyor-core/src/Surveyor/Core.hs
+++ b/surveyor-core/src/Surveyor/Core.hs
@@ -111,6 +111,7 @@ module Surveyor.Core (
   SymEx.SomeFloatModeRepr(..),
   SymEx.defaultSymbolicExecutionConfig,
   SymEx.SymbolicState(..),
+  SymEx.symbolicSessionID,
   SymEx.SessionState,
   SymEx.lookupSessionState,
   SymEx.singleSessionState,

--- a/surveyor-core/src/Surveyor/Core/Commands.hs
+++ b/surveyor-core/src/Surveyor/Core/Commands.hs
@@ -35,6 +35,7 @@ import qualified Data.Functor.Const as C
 import           Data.Maybe ( isJust )
 import qualified Data.Parameterized.List as PL
 import           Data.Parameterized.Some ( Some(..) )
+import qualified Data.Text as T
 import           Fmt ( (+||), (||+) )
 import qualified Fmt as Fmt
 import qualified Lang.Crucible.CFG.Core as CCC
@@ -294,6 +295,19 @@ beginSymbolicExecutionSetupC =
           case mcfg of
             Just (CCC.AnyCFG cfg) -> do
               let conf = SymEx.symbolicExecutionConfig symExecState
+              CS.logMessage state (SCL.msgWith { SCL.logLevel = SCL.Debug
+                                               , SCL.logSource = SCL.CommandCallback "BeginSymbolicExecution"
+                                               , SCL.logText = [ "State we are getting a config from"
+                                                               , case symExecState of
+                                                                   SymEx.Configuring {} -> "Configuring"
+                                                                   SymEx.Initializing {} -> "Initializing"
+                                                                   _ -> "Other"
+                                                               , "With config"
+                                                               , T.pack (show conf)
+                                                               , "session id:"
+                                                               , T.pack (show (curCtx ^. CCX.symExecSessionIDL))
+                                                               ]
+                                               })
               SCE.emitEvent customEventChan (SCE.BeginSymbolicExecutionSetup nonce conf (CCC.SomeCFG cfg))
             Nothing -> do
               CS.logMessage state (SCL.msgWith { SCL.logText = [Fmt.fmt ("Missing CFG for function "+||fh||+"")]

--- a/surveyor-core/src/Surveyor/Core/SymbolicExecution/Config.hs
+++ b/surveyor-core/src/Surveyor/Core/SymbolicExecution/Config.hs
@@ -64,6 +64,8 @@ data SymbolicExecutionConfig s where
                           -> T.Text
                           -> SymbolicExecutionConfig s
 
+deriving instance Show (SymbolicExecutionConfig s)
+
 instance NFData (SymbolicExecutionConfig s) where
   rnf (SymbolicExecutionConfig sid solver _fm t) =
     sid `deepseq` solver `deepseq` t `deepseq` ()

--- a/surveyor-core/src/Surveyor/Core/SymbolicExecution/Session.hs
+++ b/surveyor-core/src/Surveyor/Core/SymbolicExecution/Session.hs
@@ -12,7 +12,7 @@ import qualified Data.Parameterized.Nonce as PN
 -- This is a wrapper around a 'PN.Nonce', but a newtype to encode that we don't
 -- use the type parameter (only the state thread parameter)
 newtype SessionID s = SessionID (PN.Nonce s ())
-  deriving (Eq, Ord)
+  deriving (Eq, Ord, Show)
 
 -- | We don't have an 'NFData' instance for nonces, so we just take it to WHNF
 instance NFData (SessionID s) where


### PR DESCRIPTION
The observed issue was that selecting a solver and solving mode in the
initialization UI was not reflected in the setup UI on the next page when the
BeginSymbolicExecution command was invoked.

The cause was that the symbolic execution session ID was stale.  I didn't look
closely, but assume that we assigned an initial state there at some point.  In
the handler for `InitializeSymbolicExecution`, we created a fresh state (via
`configuringSymbolicExecution` and either the `mConfig` that was passed in or
the call to `defaultSymbolicExecutionConfig` with a fresh nonce).  This new
config has its own session ID that we inserted into the map containing all of
the active sessions, but we never set the active sessionID to that value.

The fix was in that handler, where we now modify the session ID in the current
context.

This should be progress on #10