### PR TITLE
Tr/sim val names

### DIFF
--- a/surveyor-brick/src/Surveyor/Brick.hs
+++ b/surveyor-brick/src/Surveyor/Brick.hs
@@ -303,7 +303,7 @@ emptyState mfp mloader ng customEventChan = do
              }
 
 stateFromContext :: forall arch s p sym ext rtp f a st fs
-                  . ( C.Architecture arch s
+                  . ( C.SymbolicArchitecture arch s
                     , LCB.IsSymInterface sym
                     , ext ~ C.CrucibleExt arch
                     , sym ~ WEB.ExprBuilder s st fs
@@ -393,7 +393,7 @@ stateFromContext ng mkAnalysisResult chan simState bp = do
                  , C.sArchNonce = n0
                  , C.sEventChannel = chan
                  , C.sUIExtension = uiExt
-                 , C.sValueNames = C.emptyValueNameMap
+                 , C.sValueNames = C.initialValueNames (Proxy @arch) simState
                  , C.sArchState = Just archState
                  , C.sUIMode = C.SomeUIMode C.SymbolicExecutionManager
                  }

--- a/surveyor-core/src/Surveyor/Core.hs
+++ b/surveyor-core/src/Surveyor/Core.hs
@@ -38,6 +38,7 @@ module Surveyor.Core (
   CA.FunctionHandle(..),
   CA.ParameterizedFormula(..),
   CA.prettyParameterizedFormula,
+  CA.NamedTerm(..),
   CA.SomeResult(..),
   CA.CruciblePersonality,
   CA.LLVM,
@@ -62,6 +63,7 @@ module Surveyor.Core (
   SCV.emptyValueNameMap,
   SCV.addValueName,
   SCV.lookupValueName,
+  SCV.initialValueNames,
   -- ** Modes
   M.UIMode(..),
   M.UIKind,

--- a/surveyor-core/src/Surveyor/Core/Architecture.hs
+++ b/surveyor-core/src/Surveyor/Core/Architecture.hs
@@ -27,6 +27,7 @@ module Surveyor.Core.Architecture (
   ParameterizedFormula(..),
   prettyParameterizedFormula,
   SomeResult(..),
+  NamedTerm(..),
   MC.mkPPC32Result,
   MC.mkPPC64Result,
   MC.mkX86Result,

--- a/surveyor-core/src/Surveyor/Core/Architecture/Void.hs
+++ b/surveyor-core/src/Surveyor/Core/Architecture/Void.hs
@@ -37,6 +37,7 @@ type instance CruciblePersonality Void sym = ()
 
 instance SymbolicArchitecture Void s where
   loadConcreteString _ _ _ _ = return Nothing
+  archNonceNames _ _ _ _ _ = []
 
 instance Architecture Void s where
   data ArchResult Void s = VoidAnalysisResult Void

--- a/surveyor-core/src/Surveyor/Core/SymbolicExecution.hs
+++ b/surveyor-core/src/Surveyor/Core/SymbolicExecution.hs
@@ -122,11 +122,15 @@ type Suspend = 'Suspend
 
 data SymbolicExecutionState arch s (k :: SymExK) where
   -- | Holds the current configuration during symbolic execution setup
+  --
+  -- We establish the user's solver choice (and basic configuration
+  -- w.r.t. floating point modes) early, as it could have an effect on the next
+  -- stage.
   Configuring :: SymbolicExecutionConfig s -> SymbolicExecutionState arch s Config
   -- | Holds the current set of initial register values (that can be
   -- incrementally modified via the UI/messages).  The type of the CFG fixes the
   -- shape of the initial registers.  It also contains initial values for global
-  -- variables.
+  -- variables and other memory objects.
   Initializing :: (CB.IsSymInterface sym)
                => SymbolicState arch s sym init reg
                -> SymbolicExecutionState arch s SetupArgs

--- a/surveyor-core/src/Surveyor/Core/SymbolicExecution.hs
+++ b/surveyor-core/src/Surveyor/Core/SymbolicExecution.hs
@@ -161,12 +161,6 @@ data SuspendedState sym init reg p ext args blocks ret rtp f a ctx arch s =
                  , suspendedRegVals :: Ctx.Assignment (LMCR.RegEntry sym) ctx
                  , suspendedRegSelection :: Maybe (Some (Ctx.Index ctx))
                  , suspendedCurrentValue :: Maybe (Some (LMCR.RegEntry sym))
-                 -- , suspendedNonce :: PN.Nonce s sym
-                 -- ^ A nonce to witness the compatibility of terms
-                 -- parameterized by the same nonce.  This is needed because we
-                 -- persist some state outside of this structure that needs to
-                 -- be correlated against it, while also retaining information
-                 -- about the actual type of the symbolic backend.
                  }
 
 data SymbolicExecutionException =

--- a/surveyor-core/src/Surveyor/Core/ValueNames.hs
+++ b/surveyor-core/src/Surveyor/Core/ValueNames.hs
@@ -1,17 +1,39 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE KindSignatures #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
 module Surveyor.Core.ValueNames (
   ValueNameMap,
   emptyValueNameMap,
   addValueName,
-  lookupValueName
+  lookupValueName,
+  initialValueNames
   ) where
 
+import           Control.Lens ( (^.) )
+import qualified Control.Lens as L
+import qualified Data.Foldable as F
+import qualified Data.Parameterized.Context as Ctx
 import qualified Data.Parameterized.Map as MapF
 import qualified Data.Parameterized.Nonce as PN
+import           Data.Parameterized.Some ( Some(..) )
+import           Data.Proxy ( Proxy(..) )
 import qualified Data.Text as T
+import qualified Lang.Crucible.Backend as CB
+import qualified Lang.Crucible.CFG.Core as LCCC
+import qualified Lang.Crucible.FunctionHandle as CFH
+import qualified Lang.Crucible.Simulator.CallFrame as LCSC
+import qualified Lang.Crucible.Simulator.ExecutionTree as CSET
+import qualified Lang.Crucible.Simulator.RegMap as LMCR
+import qualified Lang.Crucible.Types as LCT
 import qualified What4.BaseTypes as WT
+import qualified What4.Expr.Builder as WEB
+import qualified What4.FunctionName as WFN
+
+import qualified Surveyor.Core.Architecture as CA
 
 -- | A simple wrapper around user-specified names that has a monomorphic type parameter
 --
@@ -29,9 +51,13 @@ valueNameText (ValueName t) = t
 -- wrapper from callers
 newtype ValueNameMap s = ValueNameMap (MapF.MapF (PN.Nonce s) ValueName)
 
+-- | Construct an empty 'ValueNameMap'
 emptyValueNameMap :: ValueNameMap s
 emptyValueNameMap = ValueNameMap MapF.empty
 
+-- | Add a name for a value to the 'ValueNameMap'
+--
+-- Only values with 'PN.Nonce's can be named
 addValueName :: PN.Nonce s (tp :: WT.BaseType) -> T.Text -> ValueNameMap s -> ValueNameMap s
 addValueName nonce name (ValueNameMap m) =
   ValueNameMap (MapF.insert nonce (ValueName name) m)
@@ -39,3 +65,86 @@ addValueName nonce name (ValueNameMap m) =
 lookupValueName :: PN.Nonce s (tp :: WT.BaseType) -> ValueNameMap s -> Maybe T.Text
 lookupValueName nonce (ValueNameMap m) =
   valueNameText <$> MapF.lookup nonce m
+
+-- | Construct an initial map of value names given a suspended simulator state
+--
+-- This walks back through all of the active call frames and adds synthetic
+-- names where possible
+initialValueNames :: forall arch s ext p sym rtp f a proxy st fs
+                   . ( CA.SymbolicArchitecture arch s
+                     , ext ~ CA.CrucibleExt arch
+                     , sym ~ WEB.ExprBuilder s st fs
+                     , CB.IsSymInterface sym
+                     )
+                  => proxy arch
+                  -> CSET.SimState p sym ext rtp f a
+                  -> ValueNameMap s
+initialValueNames _ simState =
+  F.foldl' addFrameNames emptyValueNameMap frames
+  where
+    frames = simState ^. CSET.stateTree . L.to CSET.activeFrames
+    addFrameNames nms (CSET.SomeFrame sf) =
+      case sf of
+        LCSC.RF fn re ->
+          let baseName = "ReturnFrom[" <> WFN.functionName fn <> "]"
+          in F.foldl' (\nms' (CA.NamedTerm nonce nm) -> addValueName nonce nm nms') nms (nonceNames (Proxy @arch) baseName re)
+        LCSC.OF (oframe :: LCSC.OverrideFrame sym ret args) ->
+          let baseName = oframe ^. LCSC.override . L.to WFN.functionName
+              regs = oframe ^. LCSC.overrideRegMap . L.to LMCR.regMap
+              nonceWithBaseName :: forall (tp :: LCT.CrucibleType)
+                                 . [[CA.NamedTerm s]]
+                                -> Ctx.Index args tp
+                                -> [[CA.NamedTerm s]]
+              nonceWithBaseName acc idx =
+                nonceNames (Proxy @arch) (baseName <> "@" <> T.pack (show idx)) (regs Ctx.! idx) : acc
+              names = concat (Ctx.forIndex (Ctx.size regs) nonceWithBaseName [])
+          in F.foldl' (\nms' (CA.NamedTerm nonce nm) -> addValueName nonce nm nms') nms names
+        LCSC.MF (mframe@(LCSC.CallFrame { LCSC._frameCFG = cfg }) :: LCSC.CallFrame sym ext blocks ret args) ->
+          let nArgs = if mframe ^. LCSC.frameBlockID == Some (LCCC.cfgEntryBlockID cfg)
+                      then cfgArgCount cfg
+                      else 0
+              baseName = cfg ^. L.to LCCC.cfgHandle . L.to CFH.handleName . L.to WFN.functionName
+              regs = mframe ^. LCSC.frameRegs . L.to LMCR.regMap
+              nonceWithBaseName :: forall (tp :: LCT.CrucibleType)
+                                 . [[CA.NamedTerm s]]
+                                -> Ctx.Index args tp
+                                -> [[CA.NamedTerm s]]
+              nonceWithBaseName acc idx
+                | Ctx.indexVal idx < nArgs =
+                  nonceNames (Proxy @arch) (baseName <> "@" <> T.pack (show idx)) (regs Ctx.! idx) : acc
+                | otherwise = acc
+              names = concat (Ctx.forIndex (Ctx.size regs) nonceWithBaseName [])
+          in F.foldl' (\nms' (CA.NamedTerm nonce nm) -> addValueName nonce nm nms') nms names
+
+cfgArgCount :: LCCC.CFG ext blocks ctx ret -> Int
+cfgArgCount cfg =
+  Ctx.sizeInt (Ctx.size argReprs)
+  where
+    hdl = LCCC.cfgHandle cfg
+    argReprs = CFH.handleArgTypes hdl
+
+nonceNames :: forall arch s sym st fs tp proxy
+            . ( sym ~ WEB.ExprBuilder s st fs
+              , CA.SymbolicArchitecture arch s
+              , CB.IsSymInterface sym
+              )
+           => proxy arch
+           -> T.Text
+           -> LMCR.RegEntry sym tp
+           -> [CA.NamedTerm s]
+nonceNames _ baseName re =
+  case LCT.asBaseType (LMCR.regType re) of
+    LCT.AsBaseType _btr ->
+      case LMCR.regValue re of
+        WEB.AppExpr ae -> [CA.NamedTerm (WEB.appExprId ae) baseName]
+        WEB.NonceAppExpr nae -> [CA.NamedTerm (WEB.nonceExprId nae) baseName]
+        WEB.BoundVarExpr bve -> [CA.NamedTerm (WEB.bvarId bve) baseName]
+        WEB.SemiRingLiteral {} -> []
+        WEB.BoolExpr {} -> []
+        WEB.StringExpr {} -> []
+    LCT.NotBaseType ->
+      -- In cases where we don't have a base type, architecture-specific
+      -- backends can provide their own naming scheme for intrinsic values
+      case LMCR.regType re of
+        LCT.IntrinsicRepr symRepr reprs -> CA.archNonceNames (Proxy @(arch, s)) baseName symRepr reprs re
+        _ -> []


### PR DESCRIPTION
Automatically assign names to function arguments when we initialize a suspended symbolic execution state.