### PR TITLE
Move initial symbolic registers

### DIFF
--- a/surveyor-brick/src/Surveyor/Brick/Widget/SymbolicExecution/Setup.hs
+++ b/surveyor-brick/src/Surveyor/Brick/Widget/SymbolicExecution/Setup.hs
@@ -16,7 +16,7 @@ import qualified Surveyor.Core as C
 
 renderSymbolicExecutionSetup :: C.SymbolicExecutionState arch s C.SetupArgs
                              -> B.Widget Names
-renderSymbolicExecutionSetup (C.Initializing st) =
+renderSymbolicExecutionSetup (C.Initializing st _initRegs) =
   B.vBox [ B.hBox [ B.txt "Solver: ", B.txt (T.pack (show solver))
                   , B.padLeft (B.Pad 10) (B.txt "Float Mode: ")
                   , B.txt (T.pack (show fm))

--- a/surveyor-core/src/Surveyor/Core/Commands.hs
+++ b/surveyor-core/src/Surveyor/Core/Commands.hs
@@ -399,10 +399,10 @@ startSymbolicExecutionC =
     callback :: Callback s st '[]
     callback customEventChan (AR.SomeState state) PL.Nil
       | nonce <- state ^. CS.lNonce
-      , Just (Some (SymEx.Initializing symExecState)) <- curSymExState state
+      , Just (Some (SymEx.Initializing symExecState initialRegs)) <- curSymExState state
       , Just archState <- state ^. CS.lArchState = do
           let ares = archState ^. CS.lAnalysisResult
-          SCE.emitEvent customEventChan (SCE.StartSymbolicExecution nonce ares symExecState)
+          SCE.emitEvent customEventChan (SCE.StartSymbolicExecution nonce ares symExecState initialRegs)
       | otherwise =
           CS.logMessage state (SCL.msgWith { SCL.logText = ["Wrong state for starting symbolic execution"]
                                            , SCL.logLevel = SCL.Error

--- a/surveyor-core/src/Surveyor/Core/Events.hs
+++ b/surveyor-core/src/Surveyor/Core/Events.hs
@@ -25,6 +25,7 @@ import qualified Data.ElfEdit as E
 import qualified Data.Functor.Identity as I
 import           Data.Int ( Int64 )
 import           Data.Kind ( Type )
+import qualified Data.Parameterized.Context as Ctx
 import qualified Data.Parameterized.Nonce as PN
 import           Data.Parameterized.Some ( Some(..) )
 import qualified Data.Text as T
@@ -114,6 +115,7 @@ data SymbolicExecutionEvent s st where
                          => PN.Nonce s arch
                          -> A.AnalysisResult arch s
                          -> SES.SymbolicState arch s sym init reg
+                         -> Ctx.Assignment (LMCR.RegEntry sym) init
                          -> SymbolicExecutionEvent s st
   ReportSymbolicExecutionMetrics :: CSS.SessionID s -> CSP.Metrics I.Identity -> SymbolicExecutionEvent s st
   -- | Prompt the user for the name for the currently-selected value (which is

--- a/surveyor-core/src/Surveyor/Core/Handlers/SymbolicExecution.hs
+++ b/surveyor-core/src/Surveyor/Core/Handlers/SymbolicExecution.hs
@@ -79,11 +79,11 @@ handleSymbolicExecutionEvent s0 evt =
           return (SCS.State s1)
       | otherwise -> return (SCS.State s0)
 
-    SCE.StartSymbolicExecution archNonce ares symState
+    SCE.StartSymbolicExecution archNonce ares symState initialRegs
       | Just PC.Refl <- PC.testEquality archNonce (s0 ^. SCS.lNonce) -> do
         let eventChan = s0 ^. SCS.lEventChannel
         let ng = s0 ^. SCS.lNonceGenerator
-        (newState, executionLoop) <- liftIO $ SymEx.startSymbolicExecution ng archNonce eventChan ares symState
+        (newState, executionLoop) <- liftIO $ SymEx.startSymbolicExecution ng archNonce eventChan ares symState initialRegs
         task <- liftIO $ A.async $ do
           inspectState <- executionLoop
           let updateUIMode () st =
@@ -262,9 +262,6 @@ makeSuspendedState s0 archState archNonce sessionID simState reason resumeAction
                                      , SES.withSymConstraints = \x -> x
                                      , SES.someCFG = LCCC.SomeCFG parentFrameCFG
                                      , SES.symbolicGlobals = topFrame ^. LCSET.gpGlobals
-                                     -- FIXME: Factor this out from here
-                                     -- - we don't need it in this case
-                                     , SES.symbolicRegs = error "Initial symbolic regs"
                                      }
     let msg = SCL.msgWith { SCL.logText = [T.pack "Making a suspended state"]
                           }


### PR DESCRIPTION
When setting up a new symbolic execution session from within the surveyor
core (instead of outside via e.g. crux), store the initial registers in the
symbolic execution mode constructor, rather than the configuration state.  It
isn't used in all symbolic execution tasks, and is not available if we are
connecting to a session initiated by crux.

Fixes #83