### PR TITLE
Replace uses of the fmt library with prettyprinter

### DIFF
--- a/surveyor-brick/src/Surveyor/Brick/Handlers/Extension.hs
+++ b/surveyor-brick/src/Surveyor/Brick/Handlers/Extension.hs
@@ -1,13 +1,12 @@
 {-# LANGUAGE GADTs #-}
-{-# LANGUAGE OverloadedStrings #-}
 module Surveyor.Brick.Handlers.Extension ( handleExtensionEvent ) where
 
 import qualified Brick as B
 import           Control.Lens ( (&), (.~), (^.), _Just )
 import           Control.Monad.IO.Class ( liftIO )
 import qualified Data.Parameterized.Classes as PC
-import qualified Data.Text.Prettyprint.Doc as PP
-import qualified Data.Text.Prettyprint.Doc.Render.Text as PPT
+import qualified Data.Text as T
+import qualified Prettyprinter as PP
 import qualified Surveyor.Core as C
 
 import           Surveyor.Brick.Attributes ( focusedListAttr )
@@ -37,8 +36,8 @@ handleExtensionEvent s0 evt =
       , ares <- archState ^. C.lAnalysisResult
       , Just PC.Refl <- PC.testEquality (s0 ^. C.lNonce) archNonce -> do
           liftIO $ C.logMessage s0 (C.msgWith { C.logLevel = C.Debug
-                                              , C.logSource = C.EventHandler "FindBlockContaining"
-                                              , C.logText = [PPT.renderStrict (PP.layoutCompact ("Finding block at address" PP.<+> PP.pretty (C.prettyAddress addr)))]
+                                              , C.logSource = C.EventHandler (T.pack "FindBlockContaining")
+                                              , C.logText = [PP.pretty "Finding block at address" PP.<+> C.prettyAddress addr]
                                               })
           case C.containingBlocks ares addr of
             [b] -> do
@@ -66,8 +65,8 @@ handleExtensionEvent s0 evt =
           let callback b = do
                 let fh = C.blockFunction b
                 C.logMessage s0 (C.msgWith { C.logLevel = C.Debug
-                                           , C.logSource = C.EventHandler "ListBlocks"
-                                           , C.logText = [PPT.renderStrict (PP.layoutCompact ("Pushing a block to view:" PP.<+> PP.viaShow (C.blockAddress b)))]
+                                           , C.logSource = C.EventHandler (T.pack "ListBlocks")
+                                           , C.logText = [PP.pretty "Pushing a block to view:" PP.<+> PP.viaShow (C.blockAddress b)]
                                            })
                 C.sEmitEvent s0 (C.PushContext archNonce fh C.BaseRepr b)
                 C.sEmitEvent s0 (C.ViewBlock archNonce C.BaseRepr)
@@ -83,13 +82,13 @@ handleExtensionEvent s0 evt =
                 case C.functionBlocks (archState ^. C.lAnalysisResult) f of
                   [] ->
                     C.logMessage s0 (C.msgWith { C.logLevel = C.Warn
-                                               , C.logSource = C.EventHandler "ListFunctions"
-                                               , C.logText = [PPT.renderStrict (PP.layoutCompact ("Failed to find blocks for function:" PP.<+> PP.viaShow f))]
+                                               , C.logSource = C.EventHandler (T.pack "ListFunctions")
+                                               , C.logText = [PP.pretty "Failed to find blocks for function:" PP.<+> PP.viaShow f]
                                                })
                   entryBlock : _ -> do
                     C.logMessage s0 (C.msgWith { C.logLevel = C.Debug
-                                               , C.logSource = C.EventHandler "ListFunctions"
-                                               , C.logText = [PPT.renderStrict (PP.layoutCompact ("Selecting function:" PP.<+> PP.viaShow f))]
+                                               , C.logSource = C.EventHandler (T.pack "ListFunctions")
+                                               , C.logText = [PP.pretty "Selecting function:" PP.<+> PP.viaShow f]
                                                })
                     C.sEmitEvent s0 (C.PushContext archNonce f C.BaseRepr entryBlock)
                     C.sEmitEvent s0 (C.ViewFunction archNonce C.BaseRepr)

--- a/surveyor-brick/src/Surveyor/Brick/Widget/BlockSelector.hs
+++ b/surveyor-brick/src/Surveyor/Brick/Widget/BlockSelector.hs
@@ -12,6 +12,8 @@ import qualified Data.Text as T
 import qualified Data.Text.Zipper.Generic as ZG
 import qualified Data.Vector as V
 import qualified Graphics.Vty as V
+import qualified Prettyprinter as PP
+import qualified Prettyprinter.Render.Text as PPT
 
 import qualified Brick.Widget.FilterList as FL
 import qualified Surveyor.Core as C
@@ -46,12 +48,18 @@ blockSelector callback focAttr blocks =
                                 }
 
 blockToText :: (C.Architecture arch s) => C.Block arch s -> T.Text
-blockToText b = C.prettyAddress (C.blockAddress b)
+blockToText b = asText (C.prettyAddress (C.blockAddress b))
+
+asText :: PP.Doc ann -> T.Text
+asText = PPT.renderStrict . PP.layoutCompact
+
+bDoc :: PP.Doc ann -> B.Widget n
+bDoc = B.txt . asText
 
 renderBlockItem :: (C.Architecture arch s) => B.AttrName -> Bool -> C.Block arch s -> B.Widget Names
 renderBlockItem focAttr isFocused b =
   let xfrm = if isFocused then B.withAttr focAttr else id
-  in xfrm (B.txt (C.prettyAddress (C.blockAddress b)))
+  in xfrm (bDoc (C.prettyAddress (C.blockAddress b)))
 
 renderEditorContent :: (Monoid t, ZG.GenericTextZipper t) => [t] -> B.Widget Names
 renderEditorContent txts = B.str (ZG.toList (mconcat txts))

--- a/surveyor-brick/src/Surveyor/Brick/Widget/FunctionSelector.hs
+++ b/surveyor-brick/src/Surveyor/Brick/Widget/FunctionSelector.hs
@@ -12,7 +12,8 @@ import qualified Data.Text as T
 import qualified Data.Text.Zipper.Generic as ZG
 import qualified Data.Vector as V
 import qualified Graphics.Vty as V
-import           Text.Printf ( printf )
+import qualified Prettyprinter as PP
+import qualified Prettyprinter.Render.Text as PPT
 
 import qualified Brick.Match.Subword as SW
 import qualified Brick.Widget.FilterList as FL
@@ -43,8 +44,12 @@ functionSelector cb focAttr funcs =
                                 , FL.flRenderEditorContent = renderEditorContent
                                 }
 
+docText :: PP.Doc ann -> T.Text
+docText = PPT.renderStrict . PP.layoutCompact
+
 funcToText :: (C.Architecture arch s) => C.FunctionHandle arch s -> T.Text
-funcToText f = T.pack (printf "%s (%s)" (C.fhName f) (C.prettyAddress (C.fhAddress f)))
+funcToText f =
+  docText (PP.pretty (C.fhName f) PP.<+> PP.parens (C.prettyAddress (C.fhAddress f)))
 
 renderFuncItem :: (C.Architecture arch s) => B.AttrName -> Bool -> C.FunctionHandle arch s -> B.Widget Names
 renderFuncItem focAttr isFocused f =

--- a/surveyor-brick/src/Surveyor/Brick/Widget/FunctionViewer.hs
+++ b/surveyor-brick/src/Surveyor/Brick/Widget/FunctionViewer.hs
@@ -94,11 +94,15 @@ renderFunctionViewer _ares cstk fv
 
 renderNode :: (C.IR arch s) => Bool -> C.Block arch s -> B.Widget Names
 renderNode isFocused b =
-  xfrm $ B.vBox [ B.txt (C.prettyAddress (C.blockAddress b))
-                , B.txt (PPT.renderStrict (PP.layoutCompact ("(" PP.<+> PP.pretty (length (C.blockInstructions b)) PP.<+> ")")))
+  xfrm $ B.vBox [ bDoc (C.prettyAddress (C.blockAddress b))
+                , bDoc (PP.parens (PP.pretty (length (C.blockInstructions b))))
                 ]
   where
     xfrm = if isFocused then B.withAttr B.listSelectedFocusedAttr else id
 
 renderEdge :: () -> B.Widget Names
 renderEdge _el = B.emptyWidget
+
+-- | Render a doc as a Brick widget
+bDoc :: PP.Doc ann -> B.Widget names
+bDoc d = B.txt (PPT.renderStrict (PP.layoutCompact d))

--- a/surveyor-core/src/Surveyor/Core/Architecture/Class.hs
+++ b/surveyor-core/src/Surveyor/Core/Architecture/Class.hs
@@ -47,6 +47,7 @@ import           Data.Parameterized.Classes ( testEquality )
 import qualified Data.Parameterized.Nonce as NG
 import qualified Data.Set as S
 import qualified Data.Text as T
+import qualified Prettyprinter as PP
 import qualified What4.BaseTypes as WT
 import qualified What4.Expr.Builder as WEB
 
@@ -76,9 +77,9 @@ instance NFData (SomeResult s arch) where
 -- different for JVM and LLVM
 class CrucibleExtension arch where
   type family CrucibleExtensionOperand arch :: Type -> Type
-  prettyExtensionStmt :: proxy arch -> CCE.StmtExtension (CrucibleExt arch) (CCC.Reg ctx) tp -> T.Text
-  prettyExtensionApp :: proxy arch -> CCE.ExprExtension (CrucibleExt arch) (CCC.Reg ctx) tp -> T.Text
-  prettyExtensionOperand :: proxy arch -> CrucibleExtensionOperand arch s -> T.Text
+  prettyExtensionStmt :: proxy arch -> CCE.StmtExtension (CrucibleExt arch) (CCC.Reg ctx) tp -> PP.Doc ann
+  prettyExtensionApp :: proxy arch -> CCE.ExprExtension (CrucibleExt arch) (CCC.Reg ctx) tp -> PP.Doc ann
+  prettyExtensionOperand :: proxy arch -> CrucibleExtensionOperand arch s -> PP.Doc ann
   extensionExprOperands :: SCAN.NonceCache s ctx
                         -> NG.NonceGenerator IO s
                         -> CCE.ExprExtension (CrucibleExt arch) (CCC.Reg ctx) tp
@@ -231,10 +232,10 @@ class (ArchConstraints arch s) => IR (arch :: Type) (s :: Type) where
   -- | Parse a string into an architecture-specific 'Address'
   parseAddress :: String -> Maybe (Address arch s)
   -- | Pretty print an address
-  prettyAddress :: Address arch s -> T.Text
-  prettyInstruction :: Address arch s -> Instruction arch s -> T.Text
-  prettyOperand :: Address arch s -> Operand arch s -> T.Text
-  prettyOpcode :: Opcode arch s -> T.Text
+  prettyAddress :: Address arch s -> PP.Doc ann
+  prettyInstruction :: Address arch s -> Instruction arch s -> PP.Doc ann
+  prettyOperand :: Address arch s -> Operand arch s -> PP.Doc ann
+  prettyOpcode :: Opcode arch s -> PP.Doc ann
 
   showInstructionAddresses :: proxy (arch, s) -> Bool
   operandSelectable :: Operand arch s -> Bool

--- a/surveyor-core/src/Surveyor/Core/Architecture/MC.hs
+++ b/surveyor-core/src/Surveyor/Core/Architecture/MC.hs
@@ -27,21 +27,20 @@ import qualified Data.Functor.Const as C
 import           Data.Int ( Int16, Int64 )
 import qualified Data.Map as M
 import           Data.Parameterized.Classes ( ShowF(showF) )
-import qualified Data.Parameterized.TraversableFC as FC
 import qualified Data.Parameterized.Map as MapF
 import qualified Data.Parameterized.NatRepr as NR
 import qualified Data.Parameterized.Nonce as NG
 import           Data.Parameterized.Some ( Some(..) )
+import qualified Data.Parameterized.TraversableFC as FC
 import           Data.Proxy ( Proxy(..) )
 import qualified Data.Set as S
 import qualified Data.Text as T
 import qualified Data.Text.Encoding as TE
 import qualified Data.Text.Encoding.Error as TE
-import           Data.Word ( Word32, Word64 )
 import           Data.Void
+import           Data.Word ( Word32, Word64 )
 import           Numeric ( showHex )
 import qualified Prettyprinter as PP
-import qualified Prettyprinter.Render.Text as PPT
 import           Text.Read ( readMaybe )
 
 import qualified Data.Macaw.BinaryLoader as MBL
@@ -117,35 +116,35 @@ macawExtensionOperandSelectable o =
     Offset {} -> False
     Text {} -> False
 
-prettyMacawExtensionStmt :: MS.MacawStmtExtension arch f tp -> T.Text
+prettyMacawExtensionStmt :: MS.MacawStmtExtension arch f tp -> PP.Doc ann
 prettyMacawExtensionStmt s =
   case s of
-    MS.MacawReadMem {} -> T.pack "macaw:read-mem"
-    MS.MacawCondReadMem {} -> T.pack "macaw:cond-read-mem"
-    MS.MacawWriteMem {} -> T.pack "macaw:write-mem"
-    MS.MacawCondWriteMem {} -> T.pack "macaw:cond-write-mem"
-    MS.MacawGlobalPtr {} -> T.pack "macaw:global-ptr"
-    MS.MacawFreshSymbolic {} -> T.pack "macaw:fresh-symbolic"
-    MS.MacawLookupFunctionHandle {} -> T.pack "macaw:lookup-function-handle"
-    MS.MacawArchStmtExtension {} -> T.pack "macaw:arch-stmt-extension"
-    MS.MacawArchStateUpdate {} -> T.pack "macaw:arch-state-update"
-    MS.MacawInstructionStart {} -> T.pack "macaw:instruction-start"
-    MS.PtrEq {} -> T.pack "macaw:ptr-eq"
-    MS.PtrLeq {} -> T.pack "macaw:ptr-leq"
-    MS.PtrLt {} -> T.pack "macaw:ptr-lt"
-    MS.PtrMux {} -> T.pack "macaw:ptr-mux"
-    MS.PtrAdd {} -> T.pack "macaw:ptr-add"
-    MS.PtrSub {} -> T.pack "macaw:ptr-sub"
-    MS.PtrAnd {} -> T.pack "macaw:ptr-and"
+    MS.MacawReadMem {} -> PP.pretty "macaw:read-mem"
+    MS.MacawCondReadMem {} -> PP.pretty "macaw:cond-read-mem"
+    MS.MacawWriteMem {} -> PP.pretty "macaw:write-mem"
+    MS.MacawCondWriteMem {} -> PP.pretty "macaw:cond-write-mem"
+    MS.MacawGlobalPtr {} -> PP.pretty "macaw:global-ptr"
+    MS.MacawFreshSymbolic {} -> PP.pretty "macaw:fresh-symbolic"
+    MS.MacawLookupFunctionHandle {} -> PP.pretty "macaw:lookup-function-handle"
+    MS.MacawArchStmtExtension {} -> PP.pretty "macaw:arch-stmt-extension"
+    MS.MacawArchStateUpdate {} -> PP.pretty "macaw:arch-state-update"
+    MS.MacawInstructionStart {} -> PP.pretty "macaw:instruction-start"
+    MS.PtrEq {} -> PP.pretty "macaw:ptr-eq"
+    MS.PtrLeq {} -> PP.pretty "macaw:ptr-leq"
+    MS.PtrLt {} -> PP.pretty "macaw:ptr-lt"
+    MS.PtrMux {} -> PP.pretty "macaw:ptr-mux"
+    MS.PtrAdd {} -> PP.pretty "macaw:ptr-add"
+    MS.PtrSub {} -> PP.pretty "macaw:ptr-sub"
+    MS.PtrAnd {} -> PP.pretty "macaw:ptr-and"
 
-prettyMacawExtensionApp :: MS.MacawExprExtension arch f tp -> T.Text
+prettyMacawExtensionApp :: MS.MacawExprExtension arch f tp -> PP.Doc ann
 prettyMacawExtensionApp e =
   case e of
-    MS.MacawOverflows {} -> T.pack "macaw:overflows"
-    MS.PtrToBits {} -> T.pack "macaw:ptr-to-bits"
-    MS.BitsToPtr {} -> T.pack "macaw:bits-to-ptr"
-    MS.MacawNullPtr {} -> T.pack "macaw:nullptr"
-    MS.MacawBitcast {} -> T.pack "macaw:bitcast"
+    MS.MacawOverflows {} -> PP.pretty "macaw:overflows"
+    MS.PtrToBits {} -> PP.pretty "macaw:ptr-to-bits"
+    MS.BitsToPtr {} -> PP.pretty "macaw:bits-to-ptr"
+    MS.MacawNullPtr {} -> PP.pretty "macaw:nullptr"
+    MS.MacawBitcast {} -> PP.pretty "macaw:bitcast"
 
 data MacawOperand arch s where
   AddrRepr :: MM.AddrWidthRepr (MM.ArchAddrWidth arch) -> MacawOperand arch s
@@ -160,21 +159,18 @@ data MacawOperand arch s where
 
 prettyMacawExtensionOperand :: (ShowF (MM.ArchReg arch), MM.MemWidth (MM.ArchAddrWidth arch))
                             => MacawOperand arch s
-                            -> T.Text
+                            -> PP.Doc ann
 prettyMacawExtensionOperand o =
   case o of
-    AddrRepr arep -> asText (PP.brackets (PP.viaShow arep))
-    MemRepr mrep -> asText (PP.brackets (PP.viaShow mrep))
-    MachineAddress addr -> asText (PP.viaShow addr)
-    MacawTypeRepr mrep -> asText (PP.brackets (PP.viaShow mrep))
-    NatRepr mrep -> asText (PP.brackets (PP.viaShow mrep))
-    MachineRegister r -> asText (PP.pretty (showF r))
-    MacawOverflowOp oop -> asText (PP.viaShow oop)
-    Text t -> asText (PP.dquotes (PP.pretty t))
-    Offset off -> asText (PP.viaShow off)
-
-asText :: PP.Doc ann -> T.Text
-asText = PPT.renderStrict . PP.layoutCompact
+    AddrRepr arep -> PP.brackets (PP.viaShow arep)
+    MemRepr mrep -> PP.brackets (PP.viaShow mrep)
+    MachineAddress addr -> PP.viaShow addr
+    MacawTypeRepr mrep -> PP.brackets (PP.viaShow mrep)
+    NatRepr mrep -> PP.brackets (PP.viaShow mrep)
+    MachineRegister r -> PP.pretty (showF r)
+    MacawOverflowOp oop -> PP.viaShow oop
+    Text t -> PP.dquotes (PP.pretty t)
+    Offset off -> PP.viaShow off
 
 macawExtensionExprOperands :: (AC.CrucibleExtensionOperand arch ~ MacawOperand arch)
                            => SCAN.NonceCache s ctx
@@ -413,11 +409,11 @@ mcParseAddress64 t = (MM.absoluteAddr . fromIntegral) <$> mn
     mn :: Maybe Word64
     mn = readMaybe t
 
-mcPrettyAddress :: (MM.MemWidth w) => MM.MemAddr w -> T.Text
-mcPrettyAddress = T.pack . show
+mcPrettyAddress :: (MM.MemWidth w) => MM.MemAddr w -> PP.Doc ann
+mcPrettyAddress = PP.viaShow
 
-mcPrettyInstruction :: (PP.Pretty (i ())) => i () -> T.Text
-mcPrettyInstruction = T.pack . show . PP.pretty
+mcPrettyInstruction :: (PP.Pretty (i ())) => i () -> PP.Doc ann
+mcPrettyInstruction = PP.pretty
 
 mcContainingBlocks :: (w ~ MM.ArchAddrWidth arch, MM.MemWidth w)
                    => (MM.MemAddr w -> Address arch s)
@@ -502,7 +498,7 @@ toInstX86 :: (X86.Instruction X86.OnlyEncoding (), R.ConcreteAddress X86.X86_64)
 toInstX86 (i, addr) = (X86Address (MM.absoluteAddr (R.absoluteAddress addr)),
                        X86Instruction i)
 
-ppcPrettyOperand :: (MM.MemWidth w) => MM.MemAddr w -> DPPC.Operand tp -> T.Text
+ppcPrettyOperand :: (MM.MemWidth w) => MM.MemAddr w -> DPPC.Operand tp -> PP.Doc ann
 ppcPrettyOperand _addr op =
   case op of
     DPPC.Abscondbrtarget off -> textViaShow off
@@ -541,8 +537,8 @@ ppcPrettyOperand _addr op =
     DPPC.Vrrc vr -> textViaShow vr
     DPPC.Vsrc vr -> textViaShow vr
 
-textViaShow :: (Show a) => a -> T.Text
-textViaShow = PPT.renderStrict . PP.layoutCompact . PP.viaShow
+textViaShow :: (Show a) => a -> PP.Doc ann
+textViaShow = PP.viaShow
 
 instance IR PPC.PPC32 s where
   data Instruction PPC.PPC32 s = PPC32Instruction !(R.Instruction PPC.PPC32 PPC.OnlyEncoding ())
@@ -561,7 +557,7 @@ instance IR PPC.PPC32 s where
   boundValue _ = Nothing
   prettyOperand (PPC32Address addr) (PPC32Operand op) =
     ppcPrettyOperand addr op
-  prettyOpcode (PPC32Opcode opc) = T.pack (show opc)
+  prettyOpcode (PPC32Opcode opc) = PP.viaShow opc
   parseAddress t = PPC32Address <$> mcParseAddress32 t
   rawRepr = Just (\(PPC32Instruction i) -> PPC.assemble i)
   showInstructionAddresses _ = True
@@ -737,7 +733,7 @@ instance IR PPC.PPC64 s where
   boundValue _ = Nothing
   prettyOperand (PPC64Address addr) (PPC64Operand op) =
     ppcPrettyOperand addr op
-  prettyOpcode (PPC64Opcode opc) = T.pack (show opc)
+  prettyOpcode (PPC64Opcode opc) = PP.viaShow opc
   parseAddress t = PPC64Address <$> mcParseAddress64 t
   rawRepr = Just (\(PPC64Instruction i) -> PPC.assemble i)
   showInstructionAddresses _ = True
@@ -828,12 +824,12 @@ instance IR X86.X86_64 s where
   opcode (X86Instruction i) = X86Opcode (X86.instrOpcode i)
   operands (X86Instruction i) = OL.fromList (map (uncurry X86Operand) (X86.instrOperands i))
   boundValue _ = Nothing
-  prettyOpcode (X86Opcode s) = T.pack s
+  prettyOpcode (X86Opcode s) = PP.pretty s
   prettyOperand (X86Address addr) (X86Operand v _) =
     let waddr = fromIntegral (MM.addrOffset addr)
-    in T.pack (show (ppValue waddr v))
+    in PP.viaShow (ppValue waddr v)
   prettyInstruction (X86Address _addr) (X86Instruction i) =
-    T.pack (show (FD.ppInstruction (X86.toFlexInst i)))
+    PP.viaShow (FD.ppInstruction (X86.toFlexInst i))
   parseAddress t = X86Address <$> mcParseAddress64 t
   rawRepr = Just (\(X86Instruction i) -> X86.assemble i)
   showInstructionAddresses _ = True
@@ -1026,7 +1022,7 @@ ppValue base v =
       PP.viaShow sym <> PP.pretty "+" <> PP.pretty (off - fromIntegral (fromIntegral base + ioff))
 
 ppHex :: (Integral a, Show a) => a -> PP.Doc ann
-ppHex i = PP.pretty (showHex i "")
+ppHex i = PP.pretty "0x" <> PP.pretty (showHex i "")
 
 ppImm :: (Integral w, Show w) => w -> PP.Doc ann
 ppImm i | i >= 0 = PP.pretty "0x" <> ppHex i

--- a/surveyor-core/src/Surveyor/Core/Command.hs
+++ b/surveyor-core/src/Surveyor/Core/Command.hs
@@ -16,6 +16,7 @@ import qualified Data.Functor.Const as C
 import           Data.Kind ( Type )
 import qualified Data.Parameterized.List as PL
 import qualified Data.Text as T
+import qualified Prettyprinter as PP
 
 import qualified Surveyor.Core.Chan as C
 
@@ -30,7 +31,7 @@ data SomeCommand b where
 data Command (b :: Type) (tps :: [ArgumentKind b]) =
   Command { cmdName :: T.Text
           -- ^ The name of the command
-          , cmdDocstring :: T.Text
+          , cmdDocstring :: PP.Doc ()
           -- ^ Documentation for the command
           , cmdArgNames :: PL.List (C.Const T.Text) tps
           -- ^ Argument names

--- a/surveyor-core/src/Surveyor/Core/Commands.hs
+++ b/surveyor-core/src/Surveyor/Core/Commands.hs
@@ -43,9 +43,9 @@ import           Control.Lens ( (^.), (^?) )
 import qualified Data.Functor.Const as C
 import qualified Data.Parameterized.List as PL
 import           Data.Parameterized.Some ( Some(..) )
-import           Fmt ( (+||), (||+) )
-import qualified Fmt as Fmt
+import qualified Data.Text as T
 import qualified Lang.Crucible.CFG.Core as CCC
+import qualified Prettyprinter as PP
 
 import qualified Surveyor.Core.Architecture as CA
 import qualified Surveyor.Core.Arguments as AR
@@ -56,6 +56,12 @@ import qualified Surveyor.Core.Events as SCE
 import qualified Surveyor.Core.Logging as SCL
 import qualified Surveyor.Core.State as CS
 import qualified Surveyor.Core.SymbolicExecution as SymEx
+
+-- | This is a trivial wrapper to force the type of its argument to 'T.Text';
+-- this is really useful because @-XOverloadedStrings@ is enabled, and string
+-- literals are otherwise too polymorphic to use with the prettyprinter
+text :: T.Text -> PP.Doc ann
+text = PP.pretty
 
 type Command s st tps = C.Command (AR.SurveyorCommand s st) tps
 type Callback s st tps = C.Chan (SCE.Events s st)
@@ -101,7 +107,7 @@ exitC :: forall s st . Command s st '[]
 exitC =
   C.Command "exit" doc PL.Nil PL.Nil callback (const True)
   where
-    doc = "Exit the application"
+    doc = text "Cleanly shut down the application and exit"
     callback :: Callback s st '[]
     callback = \customEventChan _ PL.Nil -> SCE.emitEvent customEventChan SCE.Exit
 
@@ -109,7 +115,7 @@ describeCommandC :: forall s st . Command s st '[AR.CommandType]
 describeCommandC =
   C.Command "describe-command" doc names rep callback (const True)
   where
-    doc = "Display the docstring of the named command"
+    doc = text "Display the docstring of the named command"
     names = C.Const "command-name" PL.:< PL.Nil
     rep = AR.CommandTypeRepr PL.:< PL.Nil
     callback :: Callback s st '[AR.CommandType]
@@ -120,7 +126,7 @@ describeKeysC :: forall s st . Command s st '[]
 describeKeysC =
   C.Command "describe-keys" doc PL.Nil PL.Nil callback (const True)
   where
-    doc = "Describe the keybindings active in the current mode"
+    doc = text "Describe the keybindings active in the current mode"
     callback :: Callback s st '[]
     callback = \customEventChan _ PL.Nil ->
       SCE.emitEvent customEventChan SCE.DescribeKeys
@@ -129,7 +135,7 @@ nameValueC :: forall s st e u . (st ~ CS.S e u) => Command s st '[AR.ValueNonceT
 nameValueC =
   C.Command "name-value" doc argNames argTypes callback CS.hasCurrentValue
   where
-    doc = "Name a sub-term in a formula"
+    doc = text "Provide a name to a distinguished sub-term in a formula inside of the symbolic execution engine"
     argNames = C.Const "nonce" PL.:< C.Const "name" PL.:< PL.Nil
     argTypes = AR.ValueNonceTypeRepr PL.:< AR.StringTypeRepr PL.:< PL.Nil
     callback :: Callback s st '[AR.ValueNonceType, AR.StringType]
@@ -140,7 +146,7 @@ nameCurrentValueC :: forall s st e u . (st ~ CS.S e u) => Command s st '[AR.Stri
 nameCurrentValueC =
   C.Command "name-current-value" doc argNames argTypes callback CS.hasCurrentValue
   where
-    doc = "Name a sub-term in the current value (determined by context)"
+    doc = text "Name a sub-term in the current value (determined by context)"
     callback :: Callback s st '[AR.StringType]
     callback = \customEventChan (AR.getNonce -> AR.SomeNonce archNonce) (AR.StringArgument name PL.:< PL.Nil) ->
       SCE.emitEvent customEventChan (SCE.InitializeValueNamePrompt archNonce name)
@@ -151,7 +157,7 @@ selectNextInstructionC :: forall s st . (AR.HasNonce st) => Command s st '[]
 selectNextInstructionC =
   C.Command "select-next-instruction" doc PL.Nil PL.Nil callback (const True)
   where
-    doc = "Select the next instruction in the current block viewer"
+    doc = text "Select the next instruction in the current block viewer"
     callback :: Callback s st '[]
     callback = \customEventChan (AR.getNonce -> AR.SomeNonce archNonce) PL.Nil ->
       SCE.emitEvent customEventChan (SCE.SelectNextInstruction archNonce)
@@ -160,7 +166,7 @@ selectPreviousInstructionC :: forall s st . (AR.HasNonce st) => Command s st '[]
 selectPreviousInstructionC =
   C.Command "select-previous-instruction" doc PL.Nil PL.Nil callback (const True)
   where
-    doc = "Select the previous instruction in the current block viewer"
+    doc = text "Select the previous instruction in the current block viewer"
     callback :: Callback s st '[]
     callback = \customEventChan (AR.getNonce -> AR.SomeNonce archNonce) PL.Nil ->
       SCE.emitEvent customEventChan (SCE.SelectPreviousInstruction archNonce)
@@ -169,7 +175,7 @@ selectNextOperandC :: forall s st . (AR.HasNonce st) => Command s st '[]
 selectNextOperandC =
   C.Command "select-next-operand" doc PL.Nil PL.Nil callback (const True)
   where
-    doc = "Select the next operand of the current instruction in the current block viewer"
+    doc = text "Select the next operand of the current instruction in the current block viewer"
     callback :: Callback s st '[]
     callback = \customEventChan (AR.getNonce -> AR.SomeNonce archNonce) PL.Nil ->
       SCE.emitEvent customEventChan (SCE.SelectNextOperand archNonce)
@@ -178,7 +184,7 @@ selectPreviousOperandC :: forall s st . (AR.HasNonce st) => Command s st '[]
 selectPreviousOperandC =
   C.Command "select-previous-operand" doc PL.Nil PL.Nil callback (const True)
   where
-    doc = "Select the previous operand of the current instruction in the current block viewer"
+    doc = text "Select the previous operand of the current instruction in the current block viewer"
     callback :: Callback s st '[]
     callback = \customEventChan (AR.getNonce -> AR.SomeNonce archNonce) PL.Nil ->
       SCE.emitEvent customEventChan (SCE.SelectPreviousOperand archNonce)
@@ -187,7 +193,7 @@ resetInstructionSelectionC :: forall s st . (AR.HasNonce st) => Command s st '[]
 resetInstructionSelectionC =
   C.Command "reset-instruction-selection" doc PL.Nil PL.Nil callback (const True)
   where
-    doc = "Clear the selection in the current block viewer"
+    doc = text "Clear the selection in the current block viewer"
     callback :: Callback s st '[]
     callback = \customEventChan (AR.getNonce -> AR.SomeNonce archNonce) PL.Nil ->
       SCE.emitEvent customEventChan (SCE.ResetInstructionSelection archNonce)
@@ -196,7 +202,7 @@ contextBackC :: forall s st e u . (st ~ CS.S e u) => Command s st '[]
 contextBackC =
   C.Command "context-back" doc PL.Nil PL.Nil callback CS.hasContext
   where
-    doc = "Go backward (down) in the context stack"
+    doc = text "Go backward (down) in the context stack"
     callback :: Callback s st '[]
     callback = \customEventChan _ PL.Nil ->
       SCE.emitEvent customEventChan SCE.ContextBack
@@ -205,7 +211,7 @@ contextForwardC :: forall s st e u . (st ~ CS.S e u) => Command s st '[]
 contextForwardC =
   C.Command "context-forward" doc PL.Nil PL.Nil callback CS.hasContext
   where
-    doc = "Go forward (up) in the context stack"
+    doc = text "Go forward (up) in the context stack"
     callback :: Callback s st '[]
     callback = \customEventChan _ PL.Nil ->
       SCE.emitEvent customEventChan SCE.ContextForward
@@ -214,7 +220,7 @@ stepExecutionC :: forall s st e u . (st ~ CS.S e u) => Command s st '[]
 stepExecutionC =
   C.Command "step-execution" doc PL.Nil PL.Nil callback CS.hasSuspendedSymbolicExecutionSession
   where
-    doc = "Step execution from the current breakpoint (operates on the current symbolic execution session)"
+    doc = text "Step execution from the current breakpoint (operates on the current symbolic execution session)"
     callback :: Callback s st '[]
     callback = \customEventChan (AR.SomeState s) PL.Nil ->
       CS.withCurrentSymbolicExecutionSession s (return ()) $ \sessionID ->
@@ -224,7 +230,7 @@ stepOutExecutionC :: forall s st e u . (st ~ CS.S e u) => Command s st '[]
 stepOutExecutionC =
   C.Command "step-out-execution" doc PL.Nil PL.Nil callback CS.hasSuspendedSymbolicExecutionSession
   where
-    doc = "Step out of the current function, pausing at the return state"
+    doc = text "Step out of the current function, pausing at the return state"
     callback :: Callback s st '[]
     callback = \customEventChan (AR.SomeState s) PL.Nil ->
       CS.withCurrentSymbolicExecutionSession s (return ()) $ \sessionID ->
@@ -234,7 +240,7 @@ interruptExecutionC :: forall s st e u . (st ~ CS.S e u) => Command s st '[]
 interruptExecutionC =
   C.Command "interrupt-execution" doc PL.Nil PL.Nil callback CS.hasExecutingSymbolicExecutionSession
   where
-    doc = "Interrupt the current symbolic execution session (operates on the current symbolic execution session)"
+    doc = text "Interrupt the current symbolic execution session (operates on the current symbolic execution session)"
     callback :: Callback s st '[]
     callback = \customEventChan (AR.SomeState s) PL.Nil ->
       CS.withCurrentSymbolicExecutionSession s (return ()) $ \sessionID ->
@@ -244,7 +250,7 @@ continueExecutionC :: forall s st e u . (st ~ CS.S e u) => Command s st '[]
 continueExecutionC =
   C.Command "continue-execution" doc PL.Nil PL.Nil callback CS.hasSuspendedSymbolicExecutionSession
   where
-    doc = "Continue execution from the stopped location (operates on the current symbolic execution session)"
+    doc = text "Continue execution from the stopped location (operates on the current symbolic execution session)"
     callback :: Callback s st '[]
     callback = \customEventChan (AR.SomeState s) PL.Nil ->
       CS.withCurrentSymbolicExecutionSession s (return ()) $ \sessionID ->
@@ -254,7 +260,7 @@ enableRecordingC :: forall s st e u . (st ~ CS.S e u) => Command s st '[]
 enableRecordingC =
   C.Command "enable-recording" doc PL.Nil PL.Nil callback CS.hasSuspendedSymbolicExecutionSession
   where
-    doc = "Start recording symbolic states for replay"
+    doc = text "Start recording symbolic states for replay"
     callback :: Callback s st '[]
     callback = \customEventChan (AR.SomeState s) PL.Nil ->
       CS.withCurrentSymbolicExecutionSession s (return ()) $ \sessionID ->
@@ -264,7 +270,7 @@ disableRecordingC :: forall s st e u . (st ~ CS.S e u) => Command s st '[]
 disableRecordingC =
   C.Command "disable-recording" doc PL.Nil PL.Nil callback CS.hasSuspendedSymbolicExecutionSession
   where
-    doc = "Stop recording symbolic states for replay"
+    doc = text "Stop recording symbolic states for replay"
     callback :: Callback s st '[]
     callback = \customEventChan (AR.SomeState s) PL.Nil ->
       CS.withCurrentSymbolicExecutionSession s (return ()) $ \sessionID ->
@@ -274,7 +280,7 @@ stepTraceBackwardC :: forall s st e u . (st ~ CS.S e u) => Command s st '[]
 stepTraceBackwardC =
   C.Command "step-trace-backward" doc PL.Nil PL.Nil callback CS.hasSuspendedSymbolicExecutionSession
   where
-    doc = "Step back in the symbolic trace"
+    doc = text "Step back in the symbolic trace"
     callback :: Callback s st '[]
     callback = \customEventChan (AR.SomeState s) PL.Nil ->
       CS.withCurrentSymbolicExecutionSession s (return ()) $ \sessionID ->
@@ -284,7 +290,7 @@ stepTraceForwardC :: forall s st e u . (st ~ CS.S e u) => Command s st '[]
 stepTraceForwardC =
   C.Command "step-trace-forward" doc PL.Nil PL.Nil callback CS.hasSuspendedSymbolicExecutionSession
   where
-    doc = "Step forward in the symbolic trace"
+    doc = text "Step forward in the symbolic trace"
     callback :: Callback s st '[]
     callback = \customEventChan (AR.SomeState s) PL.Nil ->
       CS.withCurrentSymbolicExecutionSession s (return ()) $ \sessionID ->
@@ -294,7 +300,7 @@ setLogFileC :: forall s st . Command s st '[AR.FilePathType]
 setLogFileC =
   C.Command "set-log-file" doc names rep callback (const True)
   where
-    doc = "Log to a file (in addition to the internal buffer); if the provided filepath is the empty string, the default is used (~/.cache/surveyor.log)"
+    doc = text "Log to a file (in addition to the internal buffer); if the provided filepath is the empty string, the default is used (~/.cache/surveyor.log)"
     names = C.Const "file-name" PL.:< PL.Nil
     rep = AR.FilePathTypeRepr PL.:< PL.Nil
     callback :: Callback s st '[AR.FilePathType]
@@ -305,7 +311,7 @@ disableFileLoggingC :: forall s st . Command s st '[]
 disableFileLoggingC =
   C.Command "disable-file-logging" doc PL.Nil PL.Nil callback (const True)
   where
-    doc = "Disable logging to a file, if it is enabled"
+    doc = text "Disable logging to a file, if it is enabled"
     callback :: Callback s st '[]
     callback = \customEventChan _ _ ->
       SCE.emitEvent customEventChan SCE.DisableFileLogging
@@ -314,7 +320,7 @@ loadFileC :: forall s st . Command s st '[AR.FilePathType]
 loadFileC =
   C.Command "load-file" doc names rep callback (const True)
   where
-    doc = "Load a file, attempting to determine its type automatically"
+    doc = text "Load a file, attempting to determine its type automatically"
     names = C.Const "file-name" PL.:< PL.Nil
     rep = AR.FilePathTypeRepr PL.:< PL.Nil
     callback :: Callback s st '[AR.FilePathType]
@@ -325,7 +331,7 @@ loadELFC :: forall s st . Command s st '[AR.FilePathType]
 loadELFC =
   C.Command "load-elf" doc names rep callback (const True)
   where
-    doc = "Load an ELF file"
+    doc = text "Load an ELF file"
     names = C.Const "file-name" PL.:< PL.Nil
     rep = AR.FilePathTypeRepr PL.:< PL.Nil
     callback :: Callback s st '[AR.FilePathType]
@@ -336,7 +342,7 @@ loadLLVMC :: forall s st . Command s st '[AR.FilePathType]
 loadLLVMC =
   C.Command "load-llvm" doc names rep callback (const True)
   where
-    doc = "Load an LLVM bitcode file"
+    doc = text "Load an LLVM bitcode file"
     names = C.Const "file-name" PL.:< PL.Nil
     rep = AR.FilePathTypeRepr PL.:< PL.Nil
     callback :: Callback s st '[AR.FilePathType]
@@ -347,7 +353,7 @@ loadJARC :: forall s st . Command s st '[AR.FilePathType]
 loadJARC =
   C.Command "load-jar" doc names rep callback (const True)
   where
-    doc = "Load a JAR file"
+    doc = text "Load a JAR file"
     names = C.Const "file-name" PL.:< PL.Nil
     rep = AR.FilePathTypeRepr PL.:< PL.Nil
     callback :: Callback s st '[AR.FilePathType]
@@ -358,7 +364,7 @@ initializeSymbolicExecutionC :: forall s st e u . (st ~ CS.S e u) => Command s s
 initializeSymbolicExecutionC =
   C.Command "initialize-symbolic-execution" doc PL.Nil PL.Nil callback CS.hasContext
   where
-    doc = "Initialize symbolic execution for the currently-selected function"
+    doc = text "Initialize symbolic execution for the currently-selected function"
     callback :: Callback s st '[]
     callback = \customEventChan (AR.getNonce -> AR.SomeNonce archNonce) PL.Nil ->
       SCE.emitEvent customEventChan (SCE.InitializeSymbolicExecution archNonce Nothing Nothing)
@@ -367,7 +373,7 @@ beginSymbolicExecutionSetupC :: forall s st e u . (st ~ CS.S e u) => Command s s
 beginSymbolicExecutionSetupC =
   C.Command "begin-symbolic-execution-setup" doc PL.Nil PL.Nil callback CS.hasContext
   where
-    doc = "Allocate an initial symbolic execution state and prepare it for user customization"
+    doc = text "Allocate an initial symbolic execution state and prepare it for user customization"
     callback :: Callback s st '[]
     callback customEventChan (AR.SomeState state) PL.Nil
       | nonce <- state ^. CS.lNonce
@@ -381,12 +387,12 @@ beginSymbolicExecutionSetupC =
               let conf = SymEx.symbolicExecutionConfig symExecState
               SCE.emitEvent customEventChan (SCE.BeginSymbolicExecutionSetup nonce conf (CCC.SomeCFG cfg))
             Nothing ->
-              CS.logMessage state (SCL.msgWith { SCL.logText = [Fmt.fmt ("Missing CFG for function "+||fh||+"")]
+              CS.logMessage state (SCL.msgWith { SCL.logText = [text "Missing CFG for function " <> PP.viaShow fh]
                                                , SCL.logLevel = SCL.Warn
                                                , SCL.logSource = SCL.CommandCallback "BeginSymbolicExecution"
                                                })
       | otherwise =
-        CS.logMessage state (SCL.msgWith { SCL.logText = ["Missing context for symbolic execution"]
+        CS.logMessage state (SCL.msgWith { SCL.logText = [text "Missing context for symbolic execution"]
                                          , SCL.logLevel = SCL.Warn
                                          , SCL.logSource = SCL.CommandCallback "BeginSymbolicExecution"
                                          })
@@ -404,7 +410,7 @@ startSymbolicExecutionC =
           let ares = archState ^. CS.lAnalysisResult
           SCE.emitEvent customEventChan (SCE.StartSymbolicExecution nonce ares symExecState)
       | otherwise =
-          CS.logMessage state (SCL.msgWith { SCL.logText = ["Wrong state for starting symbolic execution"]
+          CS.logMessage state (SCL.msgWith { SCL.logText = [text "Wrong state for starting symbolic execution (expected Initializing)"]
                                            , SCL.logLevel = SCL.Error
                                            , SCL.logSource = SCL.CommandCallback "StartSymbolicExecution"
                                            })

--- a/surveyor-core/src/Surveyor/Core/Events.hs
+++ b/surveyor-core/src/Surveyor/Core/Events.hs
@@ -32,6 +32,7 @@ import qualified Lang.Crucible.Backend as CB
 import qualified Lang.Crucible.CFG.Core as CCC
 import qualified Lang.Crucible.Simulator.Profiling as CSP
 import qualified Lang.Crucible.Simulator.RegMap as LMCR
+import qualified Prettyprinter as PP
 import qualified What4.BaseTypes as WT
 import qualified What4.Expr.Builder as WEB
 
@@ -82,7 +83,7 @@ data InfoEvent s st where
   -- manner suitable for the UI
   DescribeCommand :: (C.CommandLike cmd) => C.SomeCommand cmd -> InfoEvent s st
   -- | Display a transient message to the user
-  EchoText :: !T.Text -> InfoEvent s st
+  EchoText :: !(PP.Doc ()) -> InfoEvent s st
   -- | A message sent by the system (after a time delay) to reset the transient
   -- message area
   ResetEchoArea :: InfoEvent s st

--- a/surveyor-core/src/Surveyor/Core/Handlers/Debugging.hs
+++ b/surveyor-core/src/Surveyor/Core/Handlers/Debugging.hs
@@ -9,9 +9,9 @@ import           Control.Monad.IO.Class ( MonadIO, liftIO )
 import qualified Data.IORef as IOR
 import           Data.Parameterized.Some ( Some(..) )
 import qualified Data.Sequence as Seq
-import qualified Data.Text as T
 import           GHC.Stack ( HasCallStack )
 import qualified Lang.Crucible.Simulator.ExecutionTree as LCSET
+import qualified Prettyprinter as PP
 
 import qualified Surveyor.Core.Architecture as SCA
 import qualified Surveyor.Core.Events as SCE
@@ -33,7 +33,7 @@ handleDebuggingEvent s0 evt =
     SCE.StepExecution sessionID
       | Just symExSt <- s0 ^? SCS.lArchState . _Just . SCS.symExStateL
       , Just (Some symEx@(SymEx.Suspended _symNonce suspSt)) <- SymEx.lookupSessionState symExSt sessionID -> do
-          let msg = SCL.msgWith { SCL.logText = [ T.pack ("Stepping session " ++ show sessionID)
+          let msg = SCL.msgWith { SCL.logText = [ PP.pretty "Stepping session " <> PP.pretty sessionID
                                                 ]
                                 }
           liftIO $ SCS.logMessage s0 msg
@@ -67,7 +67,7 @@ handleDebuggingEvent s0 evt =
     SCE.ContinueExecution sessionID
       | Just symExSt <- s0 ^? SCS.lArchState . _Just . SCS.symExStateL
       , Just (Some symEx@(SymEx.Suspended _symNonce suspSt)) <- SymEx.lookupSessionState symExSt sessionID -> do
-          let msg = SCL.msgWith { SCL.logText = [ T.pack ("Stepping session " ++ show sessionID)
+          let msg = SCL.msgWith { SCL.logText = [ PP.pretty "Stepping session " <> PP.pretty sessionID
                                                 ]
                                 }
           liftIO $ SCS.logMessage s0 msg

--- a/surveyor-core/src/Surveyor/Core/Handlers/Logging.hs
+++ b/surveyor-core/src/Surveyor/Core/Handlers/Logging.hs
@@ -1,11 +1,11 @@
 {-# LANGUAGE GADTs #-}
-{-# LANGUAGE OverloadedStrings #-}
 module Surveyor.Core.Handlers.Logging ( handleLoggingEvent ) where
 
 import qualified Control.Concurrent.Async as A
 import           Control.Lens ( (&), (^.), (.~), (%~) )
 import           Control.Monad.IO.Class ( MonadIO, liftIO )
 import qualified Data.Text as T
+import qualified Prettyprinter as PP
 
 import qualified Surveyor.Core.Architecture as SCA
 import qualified Surveyor.Core.Events as SCE
@@ -34,8 +34,8 @@ handleLoggingEvent s0 evt =
         Just (task, _) -> liftIO $ A.cancel task
       let s1 = s0 & SCS.lLogActions . SCS.lFileLogger .~ Just (newTask, newAction)
       liftIO $ SCS.logMessage s1 (SCL.msgWith { SCL.logLevel = SCL.Info
-                                              , SCL.logText = ["Logging to file " <> T.pack logFile]
-                                              , SCL.logSource = SCL.EventHandler "SetLogFile"
+                                              , SCL.logText = [PP.pretty "Logging to file " <> PP.pretty logFile]
+                                              , SCL.logSource = SCL.EventHandler (T.pack "SetLogFile")
                                               })
       return $! SCS.State s1
     SCE.DisableFileLogging -> do

--- a/surveyor-core/src/Surveyor/Core/Handlers/SymbolicExecution.hs
+++ b/surveyor-core/src/Surveyor/Core/Handlers/SymbolicExecution.hs
@@ -26,6 +26,7 @@ import qualified Lang.Crucible.Simulator.CallFrame as LCSC
 import qualified Lang.Crucible.Simulator.ExecutionTree as LCSET
 import qualified Lang.Crucible.Simulator.RegMap as CSR
 import qualified Lang.Crucible.Types as LCT
+import qualified Prettyprinter as PP
 import qualified What4.Expr.Builder as WEB
 
 import qualified Surveyor.Core.Architecture as SCA
@@ -127,15 +128,15 @@ handleSymbolicExecutionEvent s0 evt =
       | otherwise -> do
           let msg = SCL.msgWith { SCL.logLevel = SCL.Debug
                                 , SCL.logSource = SCL.EventHandler (T.pack "InitializeValueNamePrompt")
-                                , SCL.logText = [T.pack "Pattern matches failed"]
+                                , SCL.logText = [PP.pretty "Pattern matches failed"]
                                 }
           liftIO $ SCS.logMessage s0 msg
           return (SCS.State s0)
 
     SCE.UpdateSymbolicExecutionState archNonce newState
       | Just PC.Refl <- PC.testEquality archNonce (s0 ^. SCS.lNonce) -> do
-          let msg = SCL.msgWith { SCL.logText = [T.pack "Updating symbolic execution state"
-                                                , T.pack ("  Session ID is " ++ show (SymEx.symbolicSessionID newState))
+          let msg = SCL.msgWith { SCL.logText = [ PP.pretty "Updating symbolic execution state"
+                                                , PP.pretty "  Session ID is " <> PP.viaShow (SymEx.symbolicSessionID newState)
                                                 ]
                                 }
           liftIO $ SCS.logMessage s0 msg
@@ -194,8 +195,8 @@ handleSymbolicExecutionEvent s0 evt =
           --
           -- TODO In the 'LCSET.ResultState', we could instantiate the
           -- "Inspecting" state instead of the "Suspended" state
-          let msg = SCL.msgWith { SCL.logText = [ T.pack "In DebugMonitorEvent"
-                                                , T.pack ("  SessionID=" ++ show sessionID)
+          let msg = SCL.msgWith { SCL.logText = [ PP.pretty "In DebugMonitorEvent"
+                                                , PP.pretty "  SessionID=" <> PP.pretty sessionID
                                                 ]
                                 }
           liftIO $ SCS.logMessage s0 msg
@@ -207,8 +208,8 @@ handleSymbolicExecutionEvent s0 evt =
       | Just PC.Refl <- PC.testEquality archNonce (s0 ^. SCS.lNonce)
       , Just archState <- s0 ^. SCS.lArchState -> do
           let resumeAction = CCC.writeChan returnChan SEO.UnmodifiedSimState
-          let msg = SCL.msgWith { SCL.logText = [ T.pack "In OverrideMonitorEvent"
-                                                , T.pack ("  SessionID=" ++ show sessionID)
+          let msg = SCL.msgWith { SCL.logText = [ PP.pretty "In OverrideMonitorEvent"
+                                                , PP.pretty "  SessionID=" <> PP.pretty sessionID
                                                 ]
                                 }
           liftIO $ SCS.logMessage s0 msg
@@ -266,7 +267,7 @@ makeSuspendedState s0 archState archNonce sessionID simState reason resumeAction
                                      -- - we don't need it in this case
                                      , SES.symbolicRegs = error "Initial symbolic regs"
                                      }
-    let msg = SCL.msgWith { SCL.logText = [T.pack "Making a suspended state"]
+    let msg = SCL.msgWith { SCL.logText = [PP.pretty "Making a suspended state"]
                           }
     liftIO $ SCS.logMessage s0 msg
 
@@ -280,7 +281,7 @@ makeSuspendedState s0 archState archNonce sessionID simState reason resumeAction
     let s1 = s0 & SCS.lArchState . _Just . SCS.contextL .~ contextStack
                 & SCS.lUIMode .~ SCM.SomeUIMode SCM.SymbolicExecutionManager
     let curSesId = s1 ^? SCS.lArchState . _Just . SCS.contextL . SCCx.currentContext . SCCx.symExecSessionIDL
-    let msg2 = SCL.msgWith { SCL.logText = [ T.pack ("  Current session ID is " ++ show curSesId)
+    let msg2 = SCL.msgWith { SCL.logText = [ PP.pretty "  Current session ID is " <> PP.pretty curSesId
                                            ]
                            }
     liftIO $ SCS.logMessage s0 msg2

--- a/surveyor-core/src/Surveyor/Core/IRRepr.hs
+++ b/surveyor-core/src/Surveyor/Core/IRRepr.hs
@@ -10,6 +10,7 @@ module Surveyor.Core.IRRepr (
 
 import           Data.Parameterized.Classes
 import qualified Data.Parameterized.TH.GADT as PT
+import qualified Prettyprinter as PP
 
 data Macaw arch
 data Crucible arch
@@ -30,6 +31,9 @@ instance Show (IRRepr arch ir) where
       BaseRepr -> "base"
       MacawRepr -> "macaw"
       CrucibleRepr -> "crucible"
+
+instance PP.Pretty (IRRepr arch ir) where
+  pretty = PP.viaShow
 
 $(return [])
 

--- a/surveyor-core/src/Surveyor/Core/Logging/Message.hs
+++ b/surveyor-core/src/Surveyor/Core/Logging/Message.hs
@@ -57,7 +57,7 @@ data Timestamped a =
 data LogMessage =
   LogMessage { logLevel :: !Severity
              , logSource :: !Source
-             , logText :: [T.Text]
+             , logText :: [PP.Doc ()]
              , logContext :: GS.CallStack
              }
 
@@ -132,11 +132,11 @@ prettyLogMessage lm =
                   ]
     [msg] -> PP.hsep [ prettySeverity (logLevel lm)
                      , prettySource (logSource lm)
-                     , PP.pretty msg
+                     , PP.unAnnotate msg
                      ]
     msgLines ->
       let pfx = prettySeverity (logLevel lm) PP.<+> prettySource (logSource lm)
-      in pfx PP.<+> PP.align (PP.vsep (map PP.pretty msgLines))
+      in pfx PP.<+> PP.align (PP.unAnnotate (PP.vsep msgLines))
 
 instance PP.Pretty LogMessage where
   pretty = prettyLogMessage

--- a/surveyor-core/src/Surveyor/Core/Mode.hs
+++ b/surveyor-core/src/Surveyor/Core/Mode.hs
@@ -2,7 +2,6 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE KindSignatures #-}
-{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TemplateHaskell #-}
 module Surveyor.Core.Mode (
@@ -19,9 +18,7 @@ import           Data.Maybe ( isJust )
 import qualified Data.Parameterized.Classes as PC
 import qualified Data.Parameterized.Nonce as PN
 import qualified Data.Parameterized.TH.GADT as PT
-import qualified Data.Text as T
-import           Fmt ( (+|), (||+) )
-import qualified Fmt as Fmt
+import qualified Prettyprinter as PP
 
 import           Surveyor.Core.IRRepr ( IRRepr )
 
@@ -56,17 +53,17 @@ data UIMode s k where
   -- keystrokes except for C-g
   MiniBuffer :: UIMode s NormalK -> UIMode s MiniBufferK
 
-prettyMode :: UIMode s NormalK -> T.Text
+prettyMode :: UIMode s NormalK -> PP.Doc ann
 prettyMode m =
   case m of
-    Diags -> "Diagnostics"
-    Summary -> "Summary"
-    FunctionSelector -> "Function Selector"
-    BlockSelector -> "Block Selector"
-    BlockViewer _nonce repr -> Fmt.fmt ("Block Viewer[" +| repr ||+ "]")
-    FunctionViewer _nonce repr -> Fmt.fmt ("Function Viewer[" +| repr ||+ "]")
-    SemanticsViewer -> "Semantics Viewer"
-    SymbolicExecutionManager -> "Symbolic Execution Manager"
+    Diags -> PP.pretty "Diagnostics"
+    Summary -> PP.pretty "Summary"
+    FunctionSelector -> PP.pretty "Function Selector"
+    BlockSelector -> PP.pretty "Block Selector"
+    BlockViewer _nonce repr -> PP.pretty "Block Viewer" <> PP.brackets (PP.pretty repr)
+    FunctionViewer _nonce repr -> PP.pretty "Function Viewer" <> PP.brackets (PP.pretty repr)
+    SemanticsViewer -> PP.pretty "Semantics Viewer"
+    SymbolicExecutionManager -> PP.pretty "Symbolic Execution Manager"
 
 data SomeUIMode s where
   SomeMiniBuffer :: UIMode s MiniBufferK -> SomeUIMode s

--- a/surveyor-core/src/Surveyor/Core/SymbolicExecution/Session.hs
+++ b/surveyor-core/src/Surveyor/Core/SymbolicExecution/Session.hs
@@ -6,6 +6,7 @@ module Surveyor.Core.SymbolicExecution.Session (
 
 import           Control.DeepSeq ( NFData(..) )
 import qualified Data.Parameterized.Nonce as PN
+import qualified Prettyprinter as PP
 
 -- | A unique identifier for a symbolic execution task (whose state is one of 'SymbolicExecutionState')
 --
@@ -17,6 +18,9 @@ newtype SessionID s = SessionID (PN.Nonce s ())
 -- | We don't have an 'NFData' instance for nonces, so we just take it to WHNF
 instance NFData (SessionID s) where
   rnf (SessionID n) = n `seq` ()
+
+instance PP.Pretty (SessionID s) where
+  pretty (SessionID nonce) = PP.pretty "Session" <> PP.brackets (PP.pretty (PN.indexValue nonce))
 
 newSessionID :: PN.NonceGenerator IO s -> IO (SessionID s)
 newSessionID ng = SessionID <$> PN.freshNonce ng

--- a/surveyor-core/surveyor-core.cabal
+++ b/surveyor-core/surveyor-core.cabal
@@ -72,7 +72,6 @@ library
                        panic >= 0.4 && < 0.5,
                        bytestring,
                        text,
-                       fmt >= 0.6 && < 0.7,
                        vector,
                        filepath,
                        prettyprinter >= 1.7 && < 1.8,


### PR DESCRIPTION
The code was using both - this commit standardizes on the more widely-used one.

Fixes #82