### PR TITLE
Add a new abstraction for implementing event handlers

### DIFF
--- a/surveyor-brick/src/Surveyor/Brick/Handlers.hs
+++ b/surveyor-brick/src/Surveyor/Brick/Handlers.hs
@@ -149,7 +149,7 @@ handleCustomEvent s0 evt =
       s1 <- C.handleContextEvent s0 ce
       B.continue s1
     C.DebuggingEvent de -> do
-      s1 <- C.handleDebuggingEvent s0 de
+      s1 <- C.runHandlerT (C.State s0) (C.handleDebuggingEvent s0 de)
       B.continue s1
     C.ExtensionEvent ee -> handleExtensionEvent s0 ee
 

--- a/surveyor-core/src/Surveyor/Core.hs
+++ b/surveyor-core/src/Surveyor/Core.hs
@@ -204,6 +204,7 @@ module Surveyor.Core (
   EA.setEchoAreaText,
   EA.resetEchoArea,
   -- * Handlers
+  module Surveyor.Core.HandlerMonad,
   HC.handleContextEvent,
   HI.handleInfoEvent,
   HL.handleLoggingEvent,
@@ -255,6 +256,7 @@ import qualified Surveyor.Core.Handlers.Info as HI
 import qualified Surveyor.Core.Handlers.Logging as HL
 import qualified Surveyor.Core.Handlers.Debugging as HD
 import qualified Surveyor.Core.Handlers.SymbolicExecution as HS
+import           Surveyor.Core.HandlerMonad
 import qualified Surveyor.Core.IRRepr as IR
 import qualified Surveyor.Core.Keymap as K
 import qualified Surveyor.Core.Loader as CL

--- a/surveyor-core/src/Surveyor/Core/HandlerMonad.hs
+++ b/surveyor-core/src/Surveyor/Core/HandlerMonad.hs
@@ -1,0 +1,74 @@
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+module Surveyor.Core.HandlerMonad (
+  HandlerT,
+  runHandlerT,
+  withFailAction,
+  expectValue,
+  expectValueWith
+  ) where
+
+import qualified Control.Monad.Except as ME
+import qualified Control.Monad.Fail as MF
+import qualified Control.Monad.Reader as MR
+import qualified Control.Monad.Trans as MT
+import           Control.Monad.IO.Class ( MonadIO )
+
+data EarlyReturn = ReturnDefault
+
+-- | This monad transformer for supporting early returns inside of event handlers
+newtype HandlerT r m a = HandlerT (ME.ExceptT EarlyReturn (MR.ReaderT (m ()) m) a)
+  deriving ( Functor
+           , Applicative
+           , Monad
+           , MonadIO
+           , ME.MonadError EarlyReturn
+           , MR.MonadReader (m ())
+           )
+
+-- | The 'MF.MonadFail' instance for this monad initiates an early return,
+-- rather than throwing an IO exception.  This is meant to ease pattern matching.
+instance (Monad m) => MF.MonadFail (HandlerT r m) where
+  fail _ = do
+    patternMatchFailAction <- MR.ask
+    lift patternMatchFailAction
+    ME.throwError ReturnDefault
+
+lift :: (Monad m) => m () -> HandlerT r m ()
+lift = HandlerT . MT.lift . MT.lift
+
+-- | Run the handler action, returning the default value if there is an early
+-- return
+--
+-- Handlers always need to return an updated state, thus the type @r@ is fixed.
+runHandlerT :: (Monad m) => r -> HandlerT r m r -> m r
+runHandlerT def (HandlerT ex) = MR.runReaderT doException (return ())
+  where
+    doException = do
+      res <- ME.runExceptT ex
+      case res of
+        Left ReturnDefault -> return def
+        Right r -> return r
+
+-- | Set a (scoped) action to call if 'MF.fail' is invoked (e.g., via an
+-- irrefutable pattern match failure)
+--
+-- This is very useful because pattern matching is very ergonomic in the
+-- presence of GADT constraint recovery
+withFailAction :: (Monad m) => m () -> HandlerT r m a -> HandlerT r m a
+withFailAction fa = MR.local (\_ -> fa)
+
+-- | If the given value is 'Nothing', return early
+--
+-- If returning early, run the provided action (e.g., to produce a descriptive
+-- error effect)
+expectValueWith :: (Monad m) => Maybe a -> m () -> HandlerT r m a
+expectValueWith mv onFail =
+  case mv of
+    Nothing -> lift onFail >> ME.throwError ReturnDefault
+    Just v -> return v
+
+expectValue :: (Monad m) => Maybe a -> HandlerT r m a
+expectValue mv =
+  case mv of
+    Nothing -> ME.throwError ReturnDefault
+    Just v -> return v

--- a/surveyor-core/surveyor-core.cabal
+++ b/surveyor-core/surveyor-core.cabal
@@ -48,6 +48,7 @@ library
                        Surveyor.Core.SymbolicExecution.State
                        Surveyor.Core.EchoArea
                        Surveyor.Core.Events
+                       Surveyor.Core.HandlerMonad
                        Surveyor.Core.IRRepr
                        Surveyor.Core.Keymap
                        Surveyor.Core.Loader


### PR DESCRIPTION
This is an alternative to the extensive use of pattern guards in the existing
handlers.  This formulation allows for more granular error reporting in the case
that a handler cannot execute.  Currently, all of the pattern guards either
succeed or fail.  However, some would benefit from additional diagnostic output
to make failure more apparent (either via the log or minibuffer echo area).

The rest of the handlers should be updated when there is time.