### PR TITLE
Make the behavior of the "current value" a bit more predictable

### DIFF
--- a/surveyor-brick/src/Surveyor/Brick/Widget/CallStackViewer.hs
+++ b/surveyor-brick/src/Surveyor/Brick/Widget/CallStackViewer.hs
@@ -309,12 +309,20 @@ handleCallStackViewerEvent evt cs0 =
 -- currently-selected top-level value, the value from the ValueViewer is
 -- returned.  Otherwise, the top-level value in the value selector is returned
 -- (if any).
+--
+-- NOTE: This currently only returns the value selected from the stack frame,
+-- and does not fully support picking sub-values out of the ValueViewer.  The
+-- infrastructure is in place to support that, but it doesn't seem as useful.
+-- With some UI work, it might be easier to surface that capability.
 selectedValue :: (sym ~ WEB.ExprBuilder s st fs) => CallStackViewer arch s sym e -> Maybe (Some (LMCR.RegEntry sym))
 selectedValue csv = do
-  (_, CallStackFrame _cse selForm viewers _) <- csv ^. frameList . L.to BL.listSelectedElement
+  (_, CallStackFrame _cse selForm _viewers _) <- csv ^. frameList . L.to BL.listSelectedElement
+  SBV.selectedValue selForm
+  {-
   Some selValIdx <- SBV.selectedIndex selForm
   case viewers Ctx.! selValIdx of
     WrappedViewer vv ->
       case WVV.selectedValue vv of
         Nothing -> SBV.selectedValue selForm
-        Just sre -> return sre
+        Just sre -> SBV.selectedValue selForm -- return sre
+-}

--- a/surveyor-brick/src/Surveyor/Brick/Widget/CallStackViewer.hs
+++ b/surveyor-brick/src/Surveyor/Brick/Widget/CallStackViewer.hs
@@ -309,20 +309,12 @@ handleCallStackViewerEvent evt cs0 =
 -- currently-selected top-level value, the value from the ValueViewer is
 -- returned.  Otherwise, the top-level value in the value selector is returned
 -- (if any).
---
--- NOTE: This currently only returns the value selected from the stack frame,
--- and does not fully support picking sub-values out of the ValueViewer.  The
--- infrastructure is in place to support that, but it doesn't seem as useful.
--- With some UI work, it might be easier to surface that capability.
 selectedValue :: (sym ~ WEB.ExprBuilder s st fs) => CallStackViewer arch s sym e -> Maybe (Some (LMCR.RegEntry sym))
 selectedValue csv = do
-  (_, CallStackFrame _cse selForm _viewers _) <- csv ^. frameList . L.to BL.listSelectedElement
-  SBV.selectedValue selForm
-  {-
+  (_, CallStackFrame _cse selForm viewers _) <- csv ^. frameList . L.to BL.listSelectedElement
   Some selValIdx <- SBV.selectedIndex selForm
   case viewers Ctx.! selValIdx of
     WrappedViewer vv ->
       case WVV.selectedValue vv of
         Nothing -> SBV.selectedValue selForm
-        Just sre -> SBV.selectedValue selForm -- return sre
--}
+        Just sre -> return sre

--- a/surveyor-brick/src/Surveyor/Brick/Widget/ValueViewer.hs
+++ b/surveyor-brick/src/Surveyor/Brick/Widget/ValueViewer.hs
@@ -22,7 +22,7 @@ module Surveyor.Brick.Widget.ValueViewer (
 
 import qualified Brick as B
 import qualified Brick.Widgets.List as BL
-import           Control.Lens ( (^.), (&), (%~) )
+import           Control.Lens ( (^.), (&), (%~), (.~) )
 import qualified Control.Lens as L
 import qualified Control.Monad.State.Strict as St
 import qualified Data.BitVector.Sized as DBS
@@ -207,11 +207,12 @@ buildViewer tp re = do
                           , [ w | (_, w) <- Map.toList surrogateEntries ]
                           ]
   let vals = DV.fromList (if null cachedVals then [root] else cachedVals)
+  let l0 = BL.list ValueViewerList vals 1
   let vvs = ValueViewerState { regType = tp
                              , regValue = re
                              , cache = c
                              , rootWidget = renderedWidget root
-                             , valueList = BL.list ValueViewerList vals 1
+                             , valueList = l0 & BL.listSelectedL .~ Nothing
                              }
   return (ValueViewer vvs)
 


### PR DESCRIPTION
This might not be the right approach yet.  Before, even if no value was selected
in the value viewer, the first was being chosen as the selected value.   That is
clearly wrong, though the most useful correct behavior is still unclear.