### PR TITLE
Move the EchoArea into the Brick UI

### DIFF
--- a/surveyor-brick/src/Surveyor/Brick/Command.hs
+++ b/surveyor-brick/src/Surveyor/Brick/Command.hs
@@ -31,6 +31,7 @@ import qualified Data.Parameterized.List as PL
 import qualified Data.Parameterized.Nonce as PN
 import qualified Data.Text as T
 
+import qualified Surveyor.Brick.EchoArea as SBEA
 import qualified Surveyor.Brick.Extension as SBE
 import           Surveyor.Brick.Names ( Names(..) )
 import qualified Surveyor.Brick.Widget.Minibuffer as MB
@@ -48,6 +49,7 @@ mkExtension :: forall (arch :: Type) s
             -> (String -> Maybe (C.SomeAddress s)) -> T.Text -> SBE.BrickUIExtension s
 mkExtension emitEvent archNonce addrParser prompt =
   SBE.BrickUIExtension { SBE.sMinibuffer = MB.minibuffer addrParser updater MinibufferEditor MinibufferCompletionList prompt (C.allCommands ++ extraCommands)
+                       , SBE.sEchoArea = SBEA.echoArea 10 (emitEvent (C.toEvent SBE.ResetEchoArea))
                        }
   where
     updater = SBE.updateMinibufferCompletions emitEvent archNonce

--- a/surveyor-brick/src/Surveyor/Brick/EchoArea.hs
+++ b/surveyor-brick/src/Surveyor/Brick/EchoArea.hs
@@ -1,7 +1,7 @@
 -- | A data abstraction around a text value that can timeout
 --
 -- This could probably be generalized beyond just the echo area
-module Surveyor.Core.EchoArea (
+module Surveyor.Brick.EchoArea (
   EchoArea,
   echoArea,
   resetEchoArea,

--- a/surveyor-brick/src/Surveyor/Brick/Extension.hs
+++ b/surveyor-brick/src/Surveyor/Brick/Extension.hs
@@ -17,6 +17,7 @@ module Surveyor.Brick.Extension (
   -- * Lenses
   minibufferL,
   minibufferG,
+  echoAreaL,
   functionSelectorL,
   functionSelectorG,
   blockSelectorL,
@@ -39,10 +40,12 @@ import qualified Data.Parameterized.Nonce as PN
 import qualified Data.Text as T
 import qualified Data.Vector as V
 import           GHC.Generics ( Generic )
+import qualified Prettyprinter as PP
 import qualified Surveyor.Core as C
 
 import qualified Brick.Widget.Minibuffer as MBW
 
+import qualified Surveyor.Brick.EchoArea as SBEA
 import           Surveyor.Brick.Names ( Names(..) )
 import qualified Surveyor.Brick.Widget.BlockSelector as BS
 import qualified Surveyor.Brick.Widget.BlockViewer as BV
@@ -60,6 +63,7 @@ import qualified Surveyor.Brick.Widget.SymbolicExecution as SEM
 data BrickUIExtension s =
   BrickUIExtension { sMinibuffer :: !(MB.Minibuffer (C.SurveyorCommand s (C.S BrickUIExtension BrickUIState)) T.Text Names)
                    -- ^ The persistent state of the minibuffer
+                   , sEchoArea :: SBEA.EchoArea
                    }
   deriving (Generic)
 
@@ -77,7 +81,9 @@ data BrickUIState arch s =
   deriving (Generic)
 
 L.makeLensesFor
-  [("sMinibuffer", "minibufferL")]
+  [ ("sMinibuffer", "minibufferL")
+  , ("sEchoArea", "echoAreaL")
+  ]
   ''BrickUIExtension
 
 L.makeLensesFor
@@ -100,6 +106,12 @@ data BrickUIEvent s (st :: Type -> Type -> Type) where
   ShowDiagnostics :: BrickUIEvent s st
   OpenMinibuffer :: BrickUIEvent s st
   ShowSymbolicExecution :: BrickUIEvent s st
+
+  -- | Display a transient message to the user
+  EchoText :: !(PP.Doc ()) -> BrickUIEvent s st
+  -- | A message sent by the system (after a time delay) to reset the transient
+  -- message area
+  ResetEchoArea :: BrickUIEvent s st
 
   ListBlocks :: PN.Nonce s arch -> [C.Block arch s] -> BrickUIEvent s st
   ListFunctions :: PN.Nonce s arch -> [C.FunctionHandle arch s] -> BrickUIEvent s st

--- a/surveyor-brick/src/Surveyor/Brick/Handlers.hs
+++ b/surveyor-brick/src/Surveyor/Brick/Handlers.hs
@@ -141,6 +141,13 @@ handleCustomEvent s0 evt =
       handleSymbolicExecutionEvent s1 se
     C.LoggingEvent le -> do
       s1 <- C.handleLoggingEvent s0 le
+      -- Take the first line of any logs (that are not debug spam) and reflect
+      -- them into the echo area
+      case le of
+        C.LogDiagnostic msg
+          | C.logLevel (C.logMsg msg) > C.Debug
+          , firstLine : _ <- C.logText (C.logMsg msg) -> liftIO $ C.sEmitEvent s0 (SBE.EchoText firstLine)
+        _ -> return ()
       B.continue s1
     C.InfoEvent ie -> do
       s1 <- C.handleInfoEvent s0 ie

--- a/surveyor-brick/src/Surveyor/Brick/Handlers/Extension.hs
+++ b/surveyor-brick/src/Surveyor/Brick/Handlers/Extension.hs
@@ -2,14 +2,16 @@
 module Surveyor.Brick.Handlers.Extension ( handleExtensionEvent ) where
 
 import qualified Brick as B
-import           Control.Lens ( (&), (.~), (^.), _Just )
+import           Control.Lens ( (&), (.~), (^.), (%~), _Just )
 import           Control.Monad.IO.Class ( liftIO )
 import qualified Data.Parameterized.Classes as PC
 import qualified Data.Text as T
 import qualified Prettyprinter as PP
+import qualified Prettyprinter.Render.Text as PPT
 import qualified Surveyor.Core as C
 
 import           Surveyor.Brick.Attributes ( focusedListAttr )
+import qualified Surveyor.Brick.EchoArea as SBEA
 import qualified Surveyor.Brick.Extension as SBE
 import qualified Surveyor.Brick.Widget.BlockSelector as BS
 import qualified Surveyor.Brick.Widget.FunctionSelector as FS
@@ -115,3 +117,7 @@ handleExtensionEvent s0 evt =
               let s1 = s0 & C.lUIExtension . SBE.minibufferL .~ mb'
               B.continue $! C.State s1
       | otherwise -> B.continue (C.State s0)
+    SBE.EchoText txt -> do
+      ea' <- liftIO (SBEA.setEchoAreaText (SBE.sEchoArea (C.sUIExtension s0)) (PPT.renderStrict (PP.layoutCompact txt)))
+      B.continue $! C.State (s0 & C.lUIExtension . SBE.echoAreaL .~ ea')
+    SBE.ResetEchoArea -> B.continue $! C.State (s0 & C.lUIExtension . SBE.echoAreaL %~ SBEA.resetEchoArea)

--- a/surveyor-brick/surveyor-brick.cabal
+++ b/surveyor-brick/surveyor-brick.cabal
@@ -15,6 +15,7 @@ cabal-version:       >=1.10
 library
   exposed-modules:     Surveyor.Brick
                        Surveyor.Brick.Attributes
+                       Surveyor.Brick.EchoArea
                        Surveyor.Brick.Extension
                        Surveyor.Brick.Handlers
                        Surveyor.Brick.Names

--- a/surveyor-core/src/Surveyor/Core.hs
+++ b/surveyor-core/src/Surveyor/Core.hs
@@ -197,12 +197,6 @@ module Surveyor.Core (
   -- * Translation Cache
   TC.TranslationCache,
   TC.newTranslationCache,
-  -- * The EchoArea abstraction
-  EA.EchoArea,
-  EA.echoArea,
-  EA.getEchoAreaText,
-  EA.setEchoAreaText,
-  EA.resetEchoArea,
   -- * Handlers
   module Surveyor.Core.HandlerMonad,
   HC.handleContextEvent,
@@ -249,7 +243,6 @@ import qualified Surveyor.Core.Chan as CS
 import qualified Surveyor.Core.Command as CC
 import           Surveyor.Core.Commands
 import qualified Surveyor.Core.Context as CCX
-import qualified Surveyor.Core.EchoArea as EA
 import qualified Surveyor.Core.Events as CE
 import qualified Surveyor.Core.Handlers.Context as HC
 import qualified Surveyor.Core.Handlers.Info as HI

--- a/surveyor-core/src/Surveyor/Core/Events.hs
+++ b/surveyor-core/src/Surveyor/Core/Events.hs
@@ -33,7 +33,6 @@ import qualified Lang.Crucible.Backend as CB
 import qualified Lang.Crucible.CFG.Core as CCC
 import qualified Lang.Crucible.Simulator.Profiling as CSP
 import qualified Lang.Crucible.Simulator.RegMap as LMCR
-import qualified Prettyprinter as PP
 import qualified What4.BaseTypes as WT
 import qualified What4.Expr.Builder as WEB
 
@@ -83,11 +82,6 @@ data InfoEvent s st where
   -- | Show a description (help text and expected arguments) of a command in a
   -- manner suitable for the UI
   DescribeCommand :: (C.CommandLike cmd) => C.SomeCommand cmd -> InfoEvent s st
-  -- | Display a transient message to the user
-  EchoText :: !(PP.Doc ()) -> InfoEvent s st
-  -- | A message sent by the system (after a time delay) to reset the transient
-  -- message area
-  ResetEchoArea :: InfoEvent s st
   -- | Display a description of the keybindings active in the current context in
   -- a manner suitable for the UI
   DescribeKeys :: InfoEvent s st

--- a/surveyor-core/src/Surveyor/Core/State.hs
+++ b/surveyor-core/src/Surveyor/Core/State.hs
@@ -34,7 +34,6 @@ module Surveyor.Core.State (
   lLoader,
   lLogStore,
   diagnosticLevelL,
-  lEchoArea,
   lUIMode,
   lAppState,
   lEventChannel,
@@ -70,7 +69,6 @@ import qualified Surveyor.Core.Architecture as A
 import qualified Surveyor.Core.Arguments as AR
 import qualified Surveyor.Core.Chan as C
 import qualified Surveyor.Core.Context as CC
-import qualified Surveyor.Core.EchoArea as EA
 import qualified Surveyor.Core.Events as SCE
 import qualified Surveyor.Core.IRRepr as IR
 import           Surveyor.Core.Keymap ( Keymap )
@@ -180,8 +178,6 @@ data S e u (arch :: Type) s =
     , sLoader :: Maybe AsyncLoader
     , sDiagnosticLevel :: !SCL.Severity
     -- ^ The level of log to display
-    , sEchoArea :: !EA.EchoArea
-    -- ^ An area where one-line messages can be displayed
     , sUIMode :: !(SomeUIMode s)
     -- ^ The current UI mode, which drives rendering and keybindings available
     , sAppState :: AppState
@@ -221,7 +217,6 @@ L.makeLensesFor
   , ("sInputFile", "lInputFile")
   , ("sLogStore", "lLogStore")
   , ("sDiagnosticLevel", "diagnosticLevelL")
-  , ("sEchoArea", "lEchoArea")
   , ("sUIMode", "lUIMode")
   , ("sEventChannel", "lEventChannel")
   , ("sAppState", "lAppState")

--- a/surveyor-core/surveyor-core.cabal
+++ b/surveyor-core/surveyor-core.cabal
@@ -46,7 +46,6 @@ library
                        Surveyor.Core.SymbolicExecution.Override
                        Surveyor.Core.SymbolicExecution.Session
                        Surveyor.Core.SymbolicExecution.State
-                       Surveyor.Core.EchoArea
                        Surveyor.Core.Events
                        Surveyor.Core.HandlerMonad
                        Surveyor.Core.IRRepr


### PR DESCRIPTION
This didn't really need to be in the core, except that a few core functions
explicitly generated echo area updates.

This commit introduces a new policy that just reflects any non-debug log
message (at least the first line) into the echo area.  This means that the brick
UI can just postprocess any log events and update the UI if needed.  The result
is a slight simplification and is logically a bit nicer.

Fixes #92